### PR TITLE
Creating a model package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+onmsctl
+onmsctl.exe
+TODO

--- a/cli/events/events.go
+++ b/cli/events/events.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 
@@ -45,7 +46,7 @@ var CliCommand = cli.Command{
 				},
 				cli.GenericFlag{
 					Name: "severity, x",
-					Value: &common.EnumValue{
+					Value: &model.EnumValue{
 						Enum: []string{"Indeterminate", "Normal", "Warning", "Minor", "Major", "Critical"},
 					},
 					Usage: "The severity of the event: Indeterminate, Normal, Warning, Minor, Major, Critical",
@@ -76,7 +77,7 @@ func sendEvent(c *cli.Context) error {
 		return fmt.Errorf("UEI required")
 	}
 	uei := c.Args().First()
-	event := Event{
+	event := model.Event{
 		UEI:         uei,
 		NodeID:      c.Int64("nodeid"),
 		Interface:   c.String("interface"),
@@ -89,7 +90,7 @@ func sendEvent(c *cli.Context) error {
 	params := c.StringSlice("parm")
 	for _, p := range params {
 		data := strings.Split(p, "=")
-		param := Parameter{data[0], data[1]}
+		param := model.EventParam{Name: data[0], Value: data[1]}
 		event.Parameters = append(event.Parameters, param)
 	}
 	jsonBytes, _ := json.Marshal(event)
@@ -101,7 +102,7 @@ func applyEvent(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	event := Event{}
+	event := model.Event{}
 	yaml.Unmarshal(data, &event)
 	err = event.IsValid()
 	if err != nil {

--- a/cli/info/info.go
+++ b/cli/info/info.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 
@@ -19,7 +20,7 @@ var CliCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		info := OnmsInfo{}
+		info := model.OnmsInfo{}
 		json.Unmarshal(jsonInfo, &info)
 		data, _ := yaml.Marshal(&info)
 		fmt.Println(string(data))

--- a/cli/provisioning/assets.go
+++ b/cli/provisioning/assets.go
@@ -105,7 +105,7 @@ func setAsset(c *cli.Context) error {
 	if !found {
 		return fmt.Errorf("Invalid Asset Field: %s", assetKey)
 	}
-	asset := model.Asset{Name: assetKey, Value: assetValue}
+	asset := model.RequisitionAsset{Name: assetKey, Value: assetValue}
 	jsonBytes, _ := json.Marshal(asset)
 	return rest.Instance.Post("/rest/requisitions/"+foreignSource+"/nodes/"+foreignID+"/assets", jsonBytes)
 }

--- a/cli/provisioning/assets.go
+++ b/cli/provisioning/assets.go
@@ -5,14 +5,16 @@ import (
 	"fmt"
 
 	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 )
 
 // AssetsCliCommand the CLI command configuration for managing categories for requisitioned nodes
 var AssetsCliCommand = cli.Command{
-	Name:  "assets",
-	Usage: "Manage node asset fields",
+	Name:     "assets",
+	Usage:    "Manage node asset fields",
+	Category: "Requisitions",
 	Subcommands: []cli.Command{
 		{
 			Name:      "list",
@@ -103,7 +105,7 @@ func setAsset(c *cli.Context) error {
 	if !found {
 		return fmt.Errorf("Invalid Asset Field: %s", assetKey)
 	}
-	asset := Asset{Name: assetKey, Value: assetValue}
+	asset := model.Asset{Name: assetKey, Value: assetValue}
 	jsonBytes, _ := json.Marshal(asset)
 	return rest.Instance.Post("/rest/requisitions/"+foreignSource+"/nodes/"+foreignID+"/assets", jsonBytes)
 }
@@ -127,8 +129,8 @@ func deleteAsset(c *cli.Context) error {
 	return rest.Instance.Delete("/rest/requisitions/" + foreignSource + "/nodes/" + foreignID + "/assets/" + asset)
 }
 
-func getAssets(c *cli.Context) (ElementList, error) {
-	assets := ElementList{}
+func getAssets(c *cli.Context) (model.ElementList, error) {
+	assets := model.ElementList{}
 	jsonAssets, err := rest.Instance.Get("/rest/foreignSourcesConfig/assets")
 	if err != nil {
 		return assets, fmt.Errorf("Cannot retrieve asset names list")

--- a/cli/provisioning/categories.go
+++ b/cli/provisioning/categories.go
@@ -68,7 +68,7 @@ func addCategory(c *cli.Context) error {
 	if category == "" {
 		return fmt.Errorf("Category name required")
 	}
-	cat := model.Category{Name: category}
+	cat := model.RequisitionCategory{Name: category}
 	jsonBytes, _ := json.Marshal(cat)
 	return rest.Instance.Post("/rest/requisitions/"+foreignSource+"/nodes/"+foreignID+"/categories", jsonBytes)
 }

--- a/cli/provisioning/categories.go
+++ b/cli/provisioning/categories.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 )
@@ -14,6 +15,7 @@ var CategoriesCliCommand = cli.Command{
 	Name:      "category",
 	ShortName: "cat",
 	Usage:     "Manage Surveillance Categories",
+	Category:  "Requisitions",
 	Subcommands: []cli.Command{
 		{
 			Name:      "list",
@@ -66,7 +68,7 @@ func addCategory(c *cli.Context) error {
 	if category == "" {
 		return fmt.Errorf("Category name required")
 	}
-	cat := Category{Name: category}
+	cat := model.Category{Name: category}
 	jsonBytes, _ := json.Marshal(cat)
 	return rest.Instance.Post("/rest/requisitions/"+foreignSource+"/nodes/"+foreignID+"/categories", jsonBytes)
 }

--- a/cli/provisioning/interfaces.go
+++ b/cli/provisioning/interfaces.go
@@ -110,7 +110,7 @@ func showInterface(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	intf := model.Interface{}
+	intf := model.RequisitionInterface{}
 	json.Unmarshal(jsonString, &intf)
 	data, _ := yaml.Marshal(&intf)
 	fmt.Println(string(data))
@@ -133,7 +133,7 @@ func setInterface(c *cli.Context) error {
 	if ipAddress == "" {
 		return fmt.Errorf("IP Address required")
 	}
-	intf := model.Interface{
+	intf := model.RequisitionInterface{
 		IPAddress:   ipAddress,
 		Description: c.String("description"),
 		SnmpPrimary: c.String("snmpPrimary"),
@@ -163,7 +163,7 @@ func applyInterface(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	intf := model.Interface{}
+	intf := model.RequisitionInterface{}
 	yaml.Unmarshal(data, &intf)
 	err = intf.IsValid()
 	if err != nil {

--- a/cli/provisioning/interfaces.go
+++ b/cli/provisioning/interfaces.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 
@@ -16,6 +17,7 @@ var InterfacesCliCommand = cli.Command{
 	Name:      "interface",
 	ShortName: "intf",
 	Usage:     "Manage IP Interfaces",
+	Category:  "Requisitions",
 	Subcommands: []cli.Command{
 		{
 			Name:      "list",
@@ -41,7 +43,7 @@ var InterfacesCliCommand = cli.Command{
 				},
 				cli.GenericFlag{
 					Name: "snmpPrimary, p",
-					Value: &common.EnumValue{
+					Value: &model.EnumValue{
 						Enum:    []string{"P", "N", "S"},
 						Default: "N",
 					},
@@ -108,7 +110,7 @@ func showInterface(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	intf := Interface{}
+	intf := model.Interface{}
 	json.Unmarshal(jsonString, &intf)
 	data, _ := yaml.Marshal(&intf)
 	fmt.Println(string(data))
@@ -131,7 +133,7 @@ func setInterface(c *cli.Context) error {
 	if ipAddress == "" {
 		return fmt.Errorf("IP Address required")
 	}
-	intf := Interface{
+	intf := model.Interface{
 		IPAddress:   ipAddress,
 		Description: c.String("description"),
 		SnmpPrimary: c.String("snmpPrimary"),
@@ -161,7 +163,7 @@ func applyInterface(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	intf := Interface{}
+	intf := model.Interface{}
 	yaml.Unmarshal(data, &intf)
 	err = intf.IsValid()
 	if err != nil {

--- a/cli/provisioning/nodes.go
+++ b/cli/provisioning/nodes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 
@@ -13,8 +14,9 @@ import (
 
 // NodesCliCommand the CLI command configuration for managing requisitioned nodes
 var NodesCliCommand = cli.Command{
-	Name:  "node",
-	Usage: "Manage Nodes",
+	Name:     "node",
+	Usage:    "Manage Nodes",
+	Category: "Requisitions",
 	Subcommands: []cli.Command{
 		{
 			Name:      "list",
@@ -98,7 +100,7 @@ func listNodes(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("Cannot retrieve nodes from requisition %s", foreignSource)
 	}
-	requisition := Requisition{}
+	requisition := model.Requisition{}
 	json.Unmarshal(jsonBytes, &requisition)
 	writer := common.NewTableWriter()
 	fmt.Fprintln(writer, "Foreign ID\tLabel\tLocation\tInterfaces\tAssets\tCategories")
@@ -135,7 +137,7 @@ func setNode(c *cli.Context) error {
 	if foreignID == "" {
 		return fmt.Errorf("Foreign ID required")
 	}
-	node := Node{
+	node := model.Node{
 		ForeignID:           foreignID,
 		NodeLabel:           c.String("label"),
 		Location:            c.String("location"),
@@ -168,7 +170,7 @@ func applyNode(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	node := &Node{}
+	node := &model.Node{}
 	yaml.Unmarshal(data, node)
 	err = node.IsValid()
 	if err != nil {

--- a/cli/provisioning/nodes.go
+++ b/cli/provisioning/nodes.go
@@ -137,7 +137,7 @@ func setNode(c *cli.Context) error {
 	if foreignID == "" {
 		return fmt.Errorf("Foreign ID required")
 	}
-	node := model.Node{
+	node := model.RequisitionNode{
 		ForeignID:           foreignID,
 		NodeLabel:           c.String("label"),
 		Location:            c.String("location"),
@@ -170,7 +170,7 @@ func applyNode(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	node := &model.Node{}
+	node := &model.RequisitionNode{}
 	yaml.Unmarshal(data, node)
 	err = node.IsValid()
 	if err != nil {

--- a/cli/provisioning/nodes_test.go
+++ b/cli/provisioning/nodes_test.go
@@ -81,12 +81,12 @@ func TestApplyNode(t *testing.T) {
 	err = app.Run([]string{app.Name, "node", "apply", "Test"})
 	assert.Error(t, err, "YAML content cannot be empty")
 
-	var testNode = model.Node{
+	var testNode = model.RequisitionNode{
 		ForeignID: "opennms.com",
-		Interfaces: []model.Interface{
+		Interfaces: []model.RequisitionInterface{
 			{IPAddress: "www.opennms.com"},
 		},
-		Categories: []model.Category{
+		Categories: []model.RequisitionCategory{
 			{"Server"},
 		},
 	}

--- a/cli/provisioning/nodes_test.go
+++ b/cli/provisioning/nodes_test.go
@@ -3,6 +3,7 @@ package provisioning
 import (
 	"testing"
 
+	"github.com/OpenNMS/onmsctl/model"
 	"gopkg.in/yaml.v2"
 	"gotest.tools/assert"
 )
@@ -80,12 +81,12 @@ func TestApplyNode(t *testing.T) {
 	err = app.Run([]string{app.Name, "node", "apply", "Test"})
 	assert.Error(t, err, "YAML content cannot be empty")
 
-	var testNode = Node{
+	var testNode = model.Node{
 		ForeignID: "opennms.com",
-		Interfaces: []Interface{
+		Interfaces: []model.Interface{
 			{IPAddress: "www.opennms.com"},
 		},
-		Categories: []Category{
+		Categories: []model.Category{
 			{"Server"},
 		},
 	}

--- a/cli/provisioning/requisitions.go
+++ b/cli/provisioning/requisitions.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 
@@ -17,6 +18,7 @@ var RequisitionsCliCommand = cli.Command{
 	Name:      "requisition",
 	ShortName: "req",
 	Usage:     "Manage Requisitions",
+	Category:  "Requisitions",
 	Subcommands: []cli.Command{
 		{
 			Name:   "list",
@@ -55,7 +57,7 @@ var RequisitionsCliCommand = cli.Command{
 			Flags: []cli.Flag{
 				cli.GenericFlag{
 					Name: "rescanExisting, r",
-					Value: &common.EnumValue{
+					Value: &model.EnumValue{
 						Enum:    []string{"true", "false", "dbonly"},
 						Default: "true",
 					},
@@ -82,7 +84,7 @@ func listRequisitions(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("Cannot retrieve requisition statistics")
 	}
-	stats := RequisitionsStats{}
+	stats := model.RequisitionsStats{}
 	json.Unmarshal(jsonStats, &stats)
 	writer := common.NewTableWriter()
 	fmt.Fprintln(writer, "Requisition\tNodes in DB\tLast Import")
@@ -103,7 +105,7 @@ func showRequisition(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	requisition := Requisition{}
+	requisition := model.Requisition{}
 	json.Unmarshal(jsonString, &requisition)
 	data, _ := yaml.Marshal(&requisition)
 	fmt.Println(string(data))
@@ -118,7 +120,7 @@ func addRequisition(c *cli.Context) error {
 	if RequisitionExists(foreignSource) {
 		return fmt.Errorf("Requisition %s already exist", foreignSource)
 	}
-	jsonBytes, _ := json.Marshal(Requisition{Name: foreignSource})
+	jsonBytes, _ := json.Marshal(model.Requisition{Name: foreignSource})
 	return rest.Instance.Post("/rest/requisitions", jsonBytes)
 }
 
@@ -127,7 +129,7 @@ func applyRequisition(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	requisition := &Requisition{}
+	requisition := &model.Requisition{}
 	yaml.Unmarshal(data, requisition)
 	err = requisition.IsValid()
 	if err != nil {
@@ -160,7 +162,7 @@ func deleteRequisition(c *cli.Context) error {
 		return fmt.Errorf("Requisition %s doesn't exist", foreignSource)
 	}
 	// Delete all nodes from requisition
-	jsonBytes, _ := json.Marshal(Requisition{Name: foreignSource})
+	jsonBytes, _ := json.Marshal(model.Requisition{Name: foreignSource})
 	err := rest.Instance.Post("/rest/requisitions", jsonBytes)
 	if err != nil {
 		return err
@@ -190,16 +192,16 @@ func deleteRequisition(c *cli.Context) error {
 	return nil
 }
 
-func getStats(stats RequisitionsStats, foreignSource string) RequisitionStats {
+func getStats(stats model.RequisitionsStats, foreignSource string) model.RequisitionStats {
 	for _, req := range stats.ForeignSources {
 		if req.Name == foreignSource {
 			return req
 		}
 	}
-	return RequisitionStats{}
+	return model.RequisitionStats{}
 }
 
-func getDisplayTime(lastImport *common.Time) string {
+func getDisplayTime(lastImport *model.Time) string {
 	if lastImport == nil || lastImport.IsZero() {
 		return "Never"
 	}

--- a/cli/provisioning/requisitions_test.go
+++ b/cli/provisioning/requisitions_test.go
@@ -68,13 +68,13 @@ func TestApplyRequisition(t *testing.T) {
 
 	var testReq = model.Requisition{
 		Name: "WebSites",
-		Nodes: []model.Node{
+		Nodes: []model.RequisitionNode{
 			{
 				ForeignID: "opennms.com",
-				Interfaces: []model.Interface{
+				Interfaces: []model.RequisitionInterface{
 					{IPAddress: "www.opennms.com"},
 				},
-				Categories: []model.Category{
+				Categories: []model.RequisitionCategory{
 					{Name: "Server"},
 				},
 			},

--- a/cli/provisioning/requisitions_test.go
+++ b/cli/provisioning/requisitions_test.go
@@ -3,6 +3,7 @@ package provisioning
 import (
 	"testing"
 
+	"github.com/OpenNMS/onmsctl/model"
 	"gopkg.in/yaml.v2"
 	"gotest.tools/assert"
 )
@@ -65,16 +66,16 @@ func TestApplyRequisition(t *testing.T) {
 	err = app.Run([]string{app.Name, "req", "apply"})
 	assert.Error(t, err, "YAML content cannot be empty")
 
-	var testReq = Requisition{
+	var testReq = model.Requisition{
 		Name: "WebSites",
-		Nodes: []Node{
+		Nodes: []model.Node{
 			{
 				ForeignID: "opennms.com",
-				Interfaces: []Interface{
+				Interfaces: []model.Interface{
 					{IPAddress: "www.opennms.com"},
 				},
-				Categories: []Category{
-					{"Server"},
+				Categories: []model.Category{
+					{Name: "Server"},
 				},
 			},
 		},

--- a/cli/provisioning/services.go
+++ b/cli/provisioning/services.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 )
@@ -14,6 +15,7 @@ var ServicesCliCommand = cli.Command{
 	Name:      "service",
 	ShortName: "svc",
 	Usage:     "Manage Monitored Services",
+	Category:  "Requisitions",
 	Subcommands: []cli.Command{
 		{
 			Name:      "list",
@@ -56,7 +58,7 @@ func listServices(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("Cannot retrieve interfaces")
 	}
-	intf := Interface{}
+	intf := model.Interface{}
 	json.Unmarshal(jsonBytes, &intf)
 	writer := common.NewTableWriter()
 	fmt.Fprintln(writer, "Service Name")
@@ -87,7 +89,7 @@ func addService(c *cli.Context) error {
 	if service == "" {
 		return fmt.Errorf("Service name required")
 	}
-	svc := Service{Name: service}
+	svc := model.Service{Name: service}
 	jsonBytes, _ := json.Marshal(svc)
 	return rest.Instance.Post("/rest/requisitions/"+foreignSource+"/nodes/"+foreignID+"/interfaces/"+ipAddress+"/services", jsonBytes)
 }

--- a/cli/provisioning/services.go
+++ b/cli/provisioning/services.go
@@ -58,7 +58,7 @@ func listServices(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("Cannot retrieve interfaces")
 	}
-	intf := model.Interface{}
+	intf := model.RequisitionInterface{}
 	json.Unmarshal(jsonBytes, &intf)
 	writer := common.NewTableWriter()
 	fmt.Fprintln(writer, "Service Name")
@@ -89,7 +89,7 @@ func addService(c *cli.Context) error {
 	if service == "" {
 		return fmt.Errorf("Service name required")
 	}
-	svc := model.Service{Name: service}
+	svc := model.RequisitionMonitoredService{Name: service}
 	jsonBytes, _ := json.Marshal(svc)
 	return rest.Instance.Post("/rest/requisitions/"+foreignSource+"/nodes/"+foreignID+"/interfaces/"+ipAddress+"/services", jsonBytes)
 }

--- a/cli/provisioning/tests.go
+++ b/cli/provisioning/tests.go
@@ -9,22 +9,22 @@ import (
 	"testing"
 	"time"
 
-	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 	"gotest.tools/assert"
 )
 
-var testNode = Node{
+var testNode = model.Node{
 	ForeignID: "n1",
 	NodeLabel: "n1",
-	Interfaces: []Interface{
+	Interfaces: []model.Interface{
 		{IPAddress: "10.0.0.1", SnmpPrimary: "P"},
 	},
-	Categories: []Category{
+	Categories: []model.Category{
 		{"Server"},
 	},
-	Assets: []Asset{
+	Assets: []model.Asset{
 		{"city", "Durham"},
 	},
 }
@@ -46,24 +46,24 @@ func CreateTestServer(t *testing.T) *httptest.Server {
 
 		case "/rest/foreignSourcesConfig/assets":
 			assert.Equal(t, http.MethodGet, req.Method)
-			sendData(res, ElementList{1, []string{"address1", "city", "state", "zip"}})
+			sendData(res, model.ElementList{1, []string{"address1", "city", "state", "zip"}})
 
 		case "/rest/requisitionNames":
 			assert.Equal(t, http.MethodGet, req.Method)
-			sendData(res, RequisitionsList{1, []string{"Test", "Local"}})
+			sendData(res, model.RequisitionsList{1, []string{"Test", "Local"}})
 
 		case "/rest/requisitions/deployed/stats":
 			assert.Equal(t, http.MethodGet, req.Method)
-			now := common.Time{Time: time.Now()}
-			sendData(res, RequisitionsStats{1, []RequisitionStats{{"Test", 0, nil, &now}}})
+			now := model.Time{Time: time.Now()}
+			sendData(res, model.RequisitionsStats{1, []model.RequisitionStats{{"Test", 0, nil, &now}}})
 
 		case "/rest/requisitions/Test":
 			assert.Equal(t, http.MethodGet, req.Method)
-			sendData(res, Requisition{Name: "Test", Nodes: []Node{testNode}})
+			sendData(res, model.Requisition{Name: "Test", Nodes: []model.Node{testNode}})
 
 		case "/rest/requisitions":
 			assert.Equal(t, http.MethodPost, req.Method)
-			var r Requisition
+			var r model.Requisition
 			bytes, err := ioutil.ReadAll(req.Body)
 			assert.NilError(t, err)
 			err = json.Unmarshal(bytes, &r)
@@ -99,7 +99,7 @@ func CreateTestServer(t *testing.T) *httptest.Server {
 
 		case "/rest/requisitions/Test/nodes":
 			assert.Equal(t, http.MethodPost, req.Method)
-			var node Node
+			var node model.Node
 			bytes, err := ioutil.ReadAll(req.Body)
 			assert.NilError(t, err)
 			json.Unmarshal(bytes, &node)
@@ -116,7 +116,7 @@ func CreateTestServer(t *testing.T) *httptest.Server {
 
 		case "/rest/requisitions/Test/nodes/n1/interfaces":
 			assert.Equal(t, http.MethodPost, req.Method)
-			var intf Interface
+			var intf model.Interface
 			bytes, err := ioutil.ReadAll(req.Body)
 			assert.NilError(t, err)
 			json.Unmarshal(bytes, &intf)
@@ -131,7 +131,7 @@ func CreateTestServer(t *testing.T) *httptest.Server {
 
 		case "/rest/requisitions/Test/nodes/n1/assets":
 			assert.Equal(t, http.MethodPost, req.Method)
-			var asset Asset
+			var asset model.Asset
 			bytes, err := ioutil.ReadAll(req.Body)
 			assert.NilError(t, err)
 			json.Unmarshal(bytes, &asset)
@@ -143,7 +143,7 @@ func CreateTestServer(t *testing.T) *httptest.Server {
 
 		case "/rest/requisitions/Test/nodes/n1/categories":
 			assert.Equal(t, http.MethodPost, req.Method)
-			var cat Category
+			var cat model.Category
 			bytes, err := ioutil.ReadAll(req.Body)
 			assert.NilError(t, err)
 			json.Unmarshal(bytes, &cat)

--- a/cli/provisioning/tests.go
+++ b/cli/provisioning/tests.go
@@ -15,16 +15,16 @@ import (
 	"gotest.tools/assert"
 )
 
-var testNode = model.Node{
+var testNode = model.RequisitionNode{
 	ForeignID: "n1",
 	NodeLabel: "n1",
-	Interfaces: []model.Interface{
+	Interfaces: []model.RequisitionInterface{
 		{IPAddress: "10.0.0.1", SnmpPrimary: "P"},
 	},
-	Categories: []model.Category{
+	Categories: []model.RequisitionCategory{
 		{"Server"},
 	},
-	Assets: []model.Asset{
+	Assets: []model.RequisitionAsset{
 		{"city", "Durham"},
 	},
 }
@@ -59,7 +59,7 @@ func CreateTestServer(t *testing.T) *httptest.Server {
 
 		case "/rest/requisitions/Test":
 			assert.Equal(t, http.MethodGet, req.Method)
-			sendData(res, model.Requisition{Name: "Test", Nodes: []model.Node{testNode}})
+			sendData(res, model.Requisition{Name: "Test", Nodes: []model.RequisitionNode{testNode}})
 
 		case "/rest/requisitions":
 			assert.Equal(t, http.MethodPost, req.Method)
@@ -99,7 +99,7 @@ func CreateTestServer(t *testing.T) *httptest.Server {
 
 		case "/rest/requisitions/Test/nodes":
 			assert.Equal(t, http.MethodPost, req.Method)
-			var node model.Node
+			var node model.RequisitionNode
 			bytes, err := ioutil.ReadAll(req.Body)
 			assert.NilError(t, err)
 			json.Unmarshal(bytes, &node)
@@ -116,7 +116,7 @@ func CreateTestServer(t *testing.T) *httptest.Server {
 
 		case "/rest/requisitions/Test/nodes/n1/interfaces":
 			assert.Equal(t, http.MethodPost, req.Method)
-			var intf model.Interface
+			var intf model.RequisitionInterface
 			bytes, err := ioutil.ReadAll(req.Body)
 			assert.NilError(t, err)
 			json.Unmarshal(bytes, &intf)
@@ -131,7 +131,7 @@ func CreateTestServer(t *testing.T) *httptest.Server {
 
 		case "/rest/requisitions/Test/nodes/n1/assets":
 			assert.Equal(t, http.MethodPost, req.Method)
-			var asset model.Asset
+			var asset model.RequisitionAsset
 			bytes, err := ioutil.ReadAll(req.Body)
 			assert.NilError(t, err)
 			json.Unmarshal(bytes, &asset)
@@ -143,7 +143,7 @@ func CreateTestServer(t *testing.T) *httptest.Server {
 
 		case "/rest/requisitions/Test/nodes/n1/categories":
 			assert.Equal(t, http.MethodPost, req.Method)
-			var cat model.Category
+			var cat model.RequisitionCategory
 			bytes, err := ioutil.ReadAll(req.Body)
 			assert.NilError(t, err)
 			json.Unmarshal(bytes, &cat)

--- a/cli/provisioning/utils.go
+++ b/cli/provisioning/utils.go
@@ -37,8 +37,8 @@ func RequisitionExists(foreignSource string) bool {
 }
 
 // GetNode gets a node from ReST using CLI context
-func GetNode(c *cli.Context) (model.Node, error) {
-	node := model.Node{}
+func GetNode(c *cli.Context) (model.RequisitionNode, error) {
+	node := model.RequisitionNode{}
 	if !c.Args().Present() {
 		return node, fmt.Errorf("Requisition name and foreign ID required")
 	}

--- a/cli/provisioning/utils.go
+++ b/cli/provisioning/utils.go
@@ -4,17 +4,18 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 )
 
 // GetRequisitionNames gets the requisition list
-func GetRequisitionNames() (RequisitionsList, error) {
+func GetRequisitionNames() (model.RequisitionsList, error) {
 	jsonRequisitions, err := rest.Instance.Get("/rest/requisitionNames")
 	if err != nil {
-		return RequisitionsList{}, fmt.Errorf("Cannot retrieve requisition names: %s", err)
+		return model.RequisitionsList{}, fmt.Errorf("Cannot retrieve requisition names: %s", err)
 	}
-	requisitions := RequisitionsList{}
+	requisitions := model.RequisitionsList{}
 	json.Unmarshal(jsonRequisitions, &requisitions)
 	return requisitions, nil
 }
@@ -36,23 +37,23 @@ func RequisitionExists(foreignSource string) bool {
 }
 
 // GetNode gets a node from ReST using CLI context
-func GetNode(c *cli.Context) (Node, error) {
+func GetNode(c *cli.Context) (model.Node, error) {
+	node := model.Node{}
 	if !c.Args().Present() {
-		return Node{}, fmt.Errorf("Requisition name and foreign ID required")
+		return node, fmt.Errorf("Requisition name and foreign ID required")
 	}
 	foreignSource := c.Args().Get(0)
 	if !RequisitionExists(foreignSource) {
-		return Node{}, fmt.Errorf("Requisition %s doesn't exist", foreignSource)
+		return node, fmt.Errorf("Requisition %s doesn't exist", foreignSource)
 	}
 	foreignID := c.Args().Get(1)
 	if foreignID == "" {
-		return Node{}, fmt.Errorf("Foreign ID required")
+		return node, fmt.Errorf("Foreign ID required")
 	}
-	jsonBytes, err := rest.Instance.Get("/rest/requisitions/"+foreignSource+"/nodes/"+foreignID)
+	jsonBytes, err := rest.Instance.Get("/rest/requisitions/" + foreignSource + "/nodes/" + foreignID)
 	if err != nil {
-		return Node{}, fmt.Errorf("Cannot retrieve node %s from requisition %s", foreignID, foreignSource)
+		return node, fmt.Errorf("Cannot retrieve node %s from requisition %s", foreignID, foreignSource)
 	}
-	node := Node{}
 	json.Unmarshal(jsonBytes, &node)
 	return node, nil
 }

--- a/cli/snmp/snmp.go
+++ b/cli/snmp/snmp.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
 	"github.com/OpenNMS/onmsctl/rest"
 	"github.com/urfave/cli"
 
@@ -37,7 +38,7 @@ var CliCommand = cli.Command{
 			Flags: []cli.Flag{
 				cli.GenericFlag{
 					Name: "version, v",
-					Value: &common.EnumValue{
+					Value: &model.EnumValue{
 						Enum:    []string{"v1", "v2c", "v3"},
 						Default: "v2c",
 					},
@@ -82,7 +83,7 @@ var CliCommand = cli.Command{
 				},
 				cli.GenericFlag{
 					Name: "privProtocol, pp",
-					Value: &common.EnumValue{
+					Value: &model.EnumValue{
 						Enum: []string{"DES", "AES", "AES192", "AES256"},
 					},
 					Usage: "SNMPv3 Privacy Protocol: DES, AES, AES192, AES256",
@@ -93,7 +94,7 @@ var CliCommand = cli.Command{
 				},
 				cli.GenericFlag{
 					Name: "authProtocol, ap",
-					Value: &common.EnumValue{
+					Value: &model.EnumValue{
 						Enum: []string{"MD5", "SHA"},
 					},
 					Usage: "SNMPv3 Authentication Protocol: MD5, SHA",
@@ -152,7 +153,7 @@ func showSnmpConfig(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	snmp := SnmpInfo{}
+	snmp := model.SnmpInfo{}
 	json.Unmarshal(jsonString, &snmp)
 	data, _ := yaml.Marshal(&snmp)
 	fmt.Println(string(data))
@@ -167,7 +168,7 @@ func setSnmpConfig(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	snmp := SnmpInfo{
+	snmp := model.SnmpInfo{
 		Version:         c.String("version"),
 		Location:        c.String("location"),
 		Port:            c.Int("port"),
@@ -208,7 +209,7 @@ func applySnmpConfig(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	snmp := SnmpInfo{}
+	snmp := model.SnmpInfo{}
 	yaml.Unmarshal(data, &snmp)
 	err = snmp.IsValid()
 	if err != nil {

--- a/common/common.go
+++ b/common/common.go
@@ -19,7 +19,11 @@ func init() {
 	configFile := getConfigFile()
 	if fileExists(configFile) {
 		data, _ := ioutil.ReadFile(configFile)
-		yaml.Unmarshal(data, &rest.Instance)
+		err := yaml.Unmarshal(data, &rest.Instance)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: cannot read configuration file %s; %s\n", configFile, err)
+			os.Exit(1)
+		}
 	}
 }
 

--- a/model/common.go
+++ b/model/common.go
@@ -1,4 +1,4 @@
-package common
+package model
 
 import (
 	"encoding/json"

--- a/model/events.go
+++ b/model/events.go
@@ -1,25 +1,23 @@
-package events
+package model
 
 import (
 	"fmt"
 	"net"
 	"time"
-
-	"github.com/OpenNMS/onmsctl/common"
 )
 
 // SNMP an event SNMP object
 type SNMP struct {
-	ID        string       `json:"id" yaml:"id"`
-	Version   string       `json:"version,omitempty" yaml:"version,omitempty"`
-	Specific  int          `json:"specific" yaml:"specific,omitempty"`
-	Generic   int          `json:"generic" yaml:"generic,omitempty"`
-	Community string       `json:"community,omitempty" yaml:"community,omitempty"`
-	Timestamp *common.Time `json:"time-stamp,omitempty" yaml:"timeStamp,omitempty"`
+	ID        string `json:"id" yaml:"id"`
+	Version   string `json:"version,omitempty" yaml:"version,omitempty"`
+	Specific  int    `json:"specific" yaml:"specific,omitempty"`
+	Generic   int    `json:"generic" yaml:"generic,omitempty"`
+	Community string `json:"community,omitempty" yaml:"community,omitempty"`
+	Timestamp *Time  `json:"time-stamp,omitempty" yaml:"timeStamp,omitempty"`
 }
 
-// Parameter an event parameter object
-type Parameter struct {
+// EventParam an event parameter object
+type EventParam struct {
 	Name  string `json:"parmName" yaml:"name"`
 	Value string `json:"value" yaml:"value"`
 }
@@ -56,24 +54,24 @@ func (lm *LogMsg) IsValid() error {
 // Event an event object
 // Time uses a string format. Example: "Saturday, July 13, 2019 2:13:43 PM GMT"
 type Event struct {
-	SnmpMask      *Mask       `json:"mask,omitempty" json:"mask,omitempty"`
-	Snmp          *SNMP       `json:"snmp,omitempty" json:"snmp,omitempty"`
-	LogMessage    *LogMsg     `json:"logmsg,omitempty" json:"logmsg,omitempty"`
-	UEI           string      `json:"uei" yaml:"uei"`
-	Source        string      `json:"source" yaml:"source"`
-	Time          string      `json:"time,omitempty" yaml:"time,omitempty"`
-	Host          string      `json:"host,omitempty" yaml:"host,omitempty"`
-	MasterStation string      `json:"master-station,omitempty" yaml:"masterStation,omitempty"`
-	NodeID        int64       `json:"nodeid,omitempty" yaml:"nodeID,omitempty"`
-	Interface     string      `json:"interface,omitempty" yaml:"interface,omitempty"`
-	Service       string      `json:"service,omitempty" yaml:"service,omitempty"`
-	IfIndex       int         `json:"ifindex,omitempty" yaml:"ifIndex,omitempty"`
-	SnmpHost      string      `json:"snmphost,omitempty" yaml:"snmpHost,omitempty"`
-	Parameters    []Parameter `json:"parms,omitempty" yaml:"parameters,omitempty"`
-	Description   string      `json:"descr,omitempty" yaml:"description,omitempty"`
-	Severity      string      `json:"severity,omitempty" yaml:"severity,omitempty"`
-	PathOutage    string      `json:"pathoutage,omitempty" yaml:"pathOutage,omitempty"`
-	OperInstruct  string      `json:"operinstruct,omitempty" yaml:"operInstruct,omitempty"`
+	SnmpMask      *Mask        `json:"mask,omitempty" json:"mask,omitempty"`
+	Snmp          *SNMP        `json:"snmp,omitempty" json:"snmp,omitempty"`
+	LogMessage    *LogMsg      `json:"logmsg,omitempty" json:"logmsg,omitempty"`
+	UEI           string       `json:"uei" yaml:"uei"`
+	Source        string       `json:"source" yaml:"source"`
+	Time          string       `json:"time,omitempty" yaml:"time,omitempty"`
+	Host          string       `json:"host,omitempty" yaml:"host,omitempty"`
+	MasterStation string       `json:"master-station,omitempty" yaml:"masterStation,omitempty"`
+	NodeID        int64        `json:"nodeid,omitempty" yaml:"nodeID,omitempty"`
+	Interface     string       `json:"interface,omitempty" yaml:"interface,omitempty"`
+	Service       string       `json:"service,omitempty" yaml:"service,omitempty"`
+	IfIndex       int          `json:"ifindex,omitempty" yaml:"ifIndex,omitempty"`
+	SnmpHost      string       `json:"snmphost,omitempty" yaml:"snmpHost,omitempty"`
+	Parameters    []EventParam `json:"parms,omitempty" yaml:"parameters,omitempty"`
+	Description   string       `json:"descr,omitempty" yaml:"description,omitempty"`
+	Severity      string       `json:"severity,omitempty" yaml:"severity,omitempty"`
+	PathOutage    string       `json:"pathoutage,omitempty" yaml:"pathOutage,omitempty"`
+	OperInstruct  string       `json:"operinstruct,omitempty" yaml:"operInstruct,omitempty"`
 }
 
 // SetTime sets the string date based on a Time object
@@ -108,7 +106,7 @@ func (e *Event) IsValid() error {
 		}
 	}
 	if e.Severity != "" {
-		severities := common.EnumValue{
+		severities := EnumValue{
 			Enum: []string{"Indeterminate", "Normal", "Warning", "Minor", "Major", "Critical"},
 		}
 		err := severities.Set(e.Severity)

--- a/model/events.go
+++ b/model/events.go
@@ -89,7 +89,7 @@ func (e *Event) SetTime(date time.Time) {
 }
 
 // IsValid returns an error if the event object is invalid
-func (e *Event) IsValid() error {
+func (e Event) IsValid() error {
 	if e.UEI == "" {
 		return fmt.Errorf("UEI cannot be null")
 	}

--- a/model/events_test.go
+++ b/model/events_test.go
@@ -1,4 +1,4 @@
-package events
+package model
 
 import (
 	"fmt"

--- a/model/info.go
+++ b/model/info.go
@@ -1,4 +1,4 @@
-package info
+package model
 
 // OnmsInfoDatetimeFormat provides information about the time format
 type OnmsInfoDatetimeFormat struct {

--- a/model/provisioning.go
+++ b/model/provisioning.go
@@ -1,10 +1,8 @@
-package provisioning
+package model
 
 import (
 	"fmt"
 	"net"
-
-	"github.com/OpenNMS/onmsctl/common"
 )
 
 // Meta a meta-data entry
@@ -180,10 +178,10 @@ func (n *Node) IsValid() error {
 
 // Requisition a requisition or set of nodes
 type Requisition struct {
-	DateStamp  *common.Time `json:"date-stamp,omitempty" yaml:"dateStamp,omitempty"`
-	LastImport *common.Time `json:"last-import,omitempty" yaml:"lastImport,omitempty"`
-	Name       string       `json:"foreign-source" yaml:"name"`
-	Nodes      []Node       `json:"node,omitempty" yaml:"nodes,omitempty"`
+	DateStamp  *Time  `json:"date-stamp,omitempty" yaml:"dateStamp,omitempty"`
+	LastImport *Time  `json:"last-import,omitempty" yaml:"lastImport,omitempty"`
+	Name       string `json:"foreign-source" yaml:"name"`
+	Nodes      []Node `json:"node,omitempty" yaml:"nodes,omitempty"`
 }
 
 // IsValid returns an error if the requisition definition is invalid
@@ -216,10 +214,10 @@ type RequisitionsList struct {
 
 // RequisitionStats statistics about the requisition
 type RequisitionStats struct {
-	Name       string       `json:"name" yaml:"name"`
-	Count      int          `json:"count" yaml:"count"`
-	ForeignIDs []string     `json:"foreign-id" yaml:"foreignID"`
-	LastImport *common.Time `json:"last-imported,omitempty" yaml:"lastImport,omitempty"`
+	Name       string   `json:"name" yaml:"name"`
+	Count      int      `json:"count" yaml:"count"`
+	ForeignIDs []string `json:"foreign-id" yaml:"foreignID"`
+	LastImport *Time    `json:"last-imported,omitempty" yaml:"lastImport,omitempty"`
 }
 
 // RequisitionsStats statistics about all the requisitions
@@ -256,11 +254,11 @@ type Policy struct {
 
 // ForeignSourceDef a foreign source definition
 type ForeignSourceDef struct {
-	Name         string       `json:"name" yaml:"name"`
-	DateStamp    *common.Time `json:"date-stamp,omitempty" yaml:"dateStamp,omitempty"`
-	ScanInterval string       `json:"scan-interval" yaml:"scanInterval"`
-	Detectors    []Detector   `json:"detectors,omitempty" yaml:"detectors,omitempty"`
-	Policies     []Policy     `json:"policies,omitempty" yaml:"policies,omitempty"`
+	Name         string     `json:"name" yaml:"name"`
+	DateStamp    *Time      `json:"date-stamp,omitempty" yaml:"dateStamp,omitempty"`
+	ScanInterval string     `json:"scan-interval" yaml:"scanInterval"`
+	Detectors    []Detector `json:"detectors,omitempty" yaml:"detectors,omitempty"`
+	Policies     []Policy   `json:"policies,omitempty" yaml:"policies,omitempty"`
 }
 
 // Plugin a definiton class for a detector or a policy

--- a/model/provisioning.go
+++ b/model/provisioning.go
@@ -5,34 +5,34 @@ import (
 	"net"
 )
 
-// Meta a meta-data entry
-type Meta struct {
+// RequisitionMetaData a meta-data entry
+type RequisitionMetaData struct {
 	Key   string `json:"key" yaml:"key"`
 	Value string `json:"value" yaml:"value"`
 }
 
-// Service an IP interface monitored service
-type Service struct {
-	Name     string `json:"service-name" yaml:"name"`
-	MetaData []Meta `json:"meta-data,omitempty" yaml:"metaData,omitempty"`
+// RequisitionMonitoredService an IP interface monitored service
+type RequisitionMonitoredService struct {
+	Name     string                `json:"service-name" yaml:"name"`
+	MetaData []RequisitionMetaData `json:"meta-data,omitempty" yaml:"metaData,omitempty"`
 }
 
 // IsValid returns an error if the service is invalid
-func (s Service) IsValid() error {
+func (s RequisitionMonitoredService) IsValid() error {
 	if s.Name == "" {
 		return fmt.Errorf("Service name cannot be null")
 	}
 	return nil
 }
 
-// Asset a requisition node asset field
-type Asset struct {
+// RequisitionAsset a requisition node asset field
+type RequisitionAsset struct {
 	Name  string `json:"name" yaml:"name"`
 	Value string `json:"value" yaml:"value"`
 }
 
 // IsValid returns an error if asset field is invalid
-func (a Asset) IsValid() error {
+func (a RequisitionAsset) IsValid() error {
 	if a.Name == "" {
 		return fmt.Errorf("Asset name cannot be empty")
 	}
@@ -42,31 +42,31 @@ func (a Asset) IsValid() error {
 	return nil
 }
 
-// Category a requisition node category
-type Category struct {
+// RequisitionCategory a requisition node category
+type RequisitionCategory struct {
 	Name string `json:"name" yaml:"name"`
 }
 
 // IsValid returns an error if the category is invalid
-func (c Category) IsValid() error {
+func (c RequisitionCategory) IsValid() error {
 	if c.Name == "" {
 		return fmt.Errorf("Category name cannot be null")
 	}
 	return nil
 }
 
-// Interface an IP interface of a requisition node
-type Interface struct {
-	IPAddress   string    `json:"ip-addr" yaml:"ipAddress"`
-	Description string    `json:"descr,omitempty" yaml:"description,omitempty"`
-	SnmpPrimary string    `json:"snmp-primary" yaml:"snmpPrimary"`
-	Status      int       `json:"status" yaml:"status"`
-	Services    []Service `json:"monitored-service,omitempty" yaml:"services,omitempty"`
-	MetaData    []Meta    `json:"meta-data,omitempty" yaml:"metaData,omitempty"`
+// RequisitionInterface an IP interface of a requisition node
+type RequisitionInterface struct {
+	IPAddress   string                        `json:"ip-addr" yaml:"ipAddress"`
+	Description string                        `json:"descr,omitempty" yaml:"description,omitempty"`
+	SnmpPrimary string                        `json:"snmp-primary" yaml:"snmpPrimary"`
+	Status      int                           `json:"status" yaml:"status"`
+	Services    []RequisitionMonitoredService `json:"monitored-service,omitempty" yaml:"services,omitempty"`
+	MetaData    []RequisitionMetaData         `json:"meta-data,omitempty" yaml:"metaData,omitempty"`
 }
 
 // IsValid returns an error if the interface definition is invalid
-func (i *Interface) IsValid() error {
+func (i *RequisitionInterface) IsValid() error {
 	if i.IPAddress == "" {
 		return fmt.Errorf("IP Address cannot be empty")
 	}
@@ -107,24 +107,24 @@ func (i *Interface) IsValid() error {
 	return nil
 }
 
-// Node a requisition node
-type Node struct {
-	NodeLabel           string      `json:"node-label" yaml:"nodeLabel"`
-	ForeignID           string      `json:"foreign-id" yaml:"foreignID"`
-	Location            string      `json:"location,omitempty" yaml:"location,omitempty"`
-	City                string      `json:"city,omitempty" yaml:"city,omitempty"`
-	Building            string      `json:"building,omitempty" yaml:"building,omitempty"`
-	ParentForeignSource string      `json:"parent-foreign-source,omitempty" yaml:"parentForeignSource,omitempty"`
-	ParentForeignID     string      `json:"parent-foreign-id,omitempty" yaml:"parentForeignID,omitempty"`
-	ParentNodeLabel     string      `json:"parent-node-label,omitempty" yaml:"parentNodeLabel,omitempty"`
-	Interfaces          []Interface `json:"interface,omitempty" yaml:"interfaces,omitempty"`
-	Categories          []Category  `json:"category,omitempty" yaml:"categories,omitempty"`
-	Assets              []Asset     `json:"asset,omitempty" yaml:"assets,omitempty"`
-	MetaData            []Meta      `json:"meta-data,omitempty" yaml:"metaData,omitempty"`
+// RequisitionNode a requisitioned node
+type RequisitionNode struct {
+	NodeLabel           string                 `json:"node-label" yaml:"nodeLabel"`
+	ForeignID           string                 `json:"foreign-id" yaml:"foreignID"`
+	Location            string                 `json:"location,omitempty" yaml:"location,omitempty"`
+	City                string                 `json:"city,omitempty" yaml:"city,omitempty"`
+	Building            string                 `json:"building,omitempty" yaml:"building,omitempty"`
+	ParentForeignSource string                 `json:"parent-foreign-source,omitempty" yaml:"parentForeignSource,omitempty"`
+	ParentForeignID     string                 `json:"parent-foreign-id,omitempty" yaml:"parentForeignID,omitempty"`
+	ParentNodeLabel     string                 `json:"parent-node-label,omitempty" yaml:"parentNodeLabel,omitempty"`
+	Interfaces          []RequisitionInterface `json:"interface,omitempty" yaml:"interfaces,omitempty"`
+	Categories          []RequisitionCategory  `json:"category,omitempty" yaml:"categories,omitempty"`
+	Assets              []RequisitionAsset     `json:"asset,omitempty" yaml:"assets,omitempty"`
+	MetaData            []RequisitionMetaData  `json:"meta-data,omitempty" yaml:"metaData,omitempty"`
 }
 
 // IsValid returns an error if the node definition is invalid
-func (n *Node) IsValid() error {
+func (n *RequisitionNode) IsValid() error {
 	if n.ForeignID == "" {
 		return fmt.Errorf("Foreign ID cannot be empty")
 	}
@@ -178,10 +178,10 @@ func (n *Node) IsValid() error {
 
 // Requisition a requisition or set of nodes
 type Requisition struct {
-	DateStamp  *Time  `json:"date-stamp,omitempty" yaml:"dateStamp,omitempty"`
-	LastImport *Time  `json:"last-import,omitempty" yaml:"lastImport,omitempty"`
-	Name       string `json:"foreign-source" yaml:"name"`
-	Nodes      []Node `json:"node,omitempty" yaml:"nodes,omitempty"`
+	DateStamp  *Time             `json:"date-stamp,omitempty" yaml:"dateStamp,omitempty"`
+	LastImport *Time             `json:"last-import,omitempty" yaml:"lastImport,omitempty"`
+	Name       string            `json:"foreign-source" yaml:"name"`
+	Nodes      []RequisitionNode `json:"node,omitempty" yaml:"nodes,omitempty"`
 }
 
 // IsValid returns an error if the requisition definition is invalid

--- a/model/provisioning_test.go
+++ b/model/provisioning_test.go
@@ -9,10 +9,10 @@ import (
 func TestRequisitionObject(t *testing.T) {
 	req := Requisition{
 		Name: "Test",
-		Nodes: []Node{
+		Nodes: []RequisitionNode{
 			{
 				ForeignID: "opennms.com",
-				Interfaces: []Interface{
+				Interfaces: []RequisitionInterface{
 					{
 						IPAddress: "www.opennms.com",
 					},

--- a/model/provisioning_test.go
+++ b/model/provisioning_test.go
@@ -1,4 +1,4 @@
-package provisioning
+package model
 
 import (
 	"testing"

--- a/model/snmp.go
+++ b/model/snmp.go
@@ -1,4 +1,4 @@
-package snmp
+package model
 
 import (
 	"fmt"

--- a/onmsctl.go
+++ b/onmsctl.go
@@ -20,7 +20,7 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		fmt.Printf("ERROR: %s\n", err)
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 		os.Exit(1)
 	}
 }
@@ -61,9 +61,9 @@ func initCliFlags(app *cli.App) {
 
 func initCliCommands(app *cli.App) {
 	app.Commands = []cli.Command{
+		info.CliCommand,
 		provisioning.CliCommand,
 		snmp.CliCommand,
-		info.CliCommand,
 		events.CliCommand,
 	}
 }

--- a/onmsctl.go
+++ b/onmsctl.go
@@ -51,6 +51,11 @@ func initCliFlags(app *cli.App) {
 			Value: rest.Instance.Password,
 			Usage: "OpenNMS User's Password",
 		},
+		cli.BoolFlag{
+			Name:        "insecure-https",
+			Destination: &rest.Instance.InsecureSkipVerify,
+			Usage:       "to skip HTTPS certificate validation (for self-signed certificates)",
+		},
 	}
 }
 

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -37,7 +37,7 @@ func (cli Client) Get(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	setCommonHeaders(cli, request)
+	cli.setCommonHeaders(request)
 	response, err := cli.getHTTPClient().Do(request)
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func (cli Client) Post(path string, jsonBytes []byte) error {
 	if err != nil {
 		return err
 	}
-	setCommonHeaders(cli, request)
+	cli.setCommonHeaders(request)
 	request.Header.Set("Content-Type", "application/json")
 	response, err := cli.getHTTPClient().Do(request)
 	if err != nil {
@@ -70,7 +70,7 @@ func (cli Client) Delete(path string) error {
 	if err != nil {
 		return err
 	}
-	setCommonHeaders(cli, request)
+	cli.setCommonHeaders(request)
 	response, err := cli.getHTTPClient().Do(request)
 	if err != nil {
 		return err
@@ -84,7 +84,7 @@ func (cli Client) Put(path string, jsonBytes []byte) error {
 	if err != nil {
 		return err
 	}
-	setCommonHeaders(cli, request)
+	cli.setCommonHeaders(request)
 	request.Header.Set("Content-Type", "application/json")
 	response, err := cli.getHTTPClient().Do(request)
 	if err != nil {
@@ -93,7 +93,7 @@ func (cli Client) Put(path string, jsonBytes []byte) error {
 	return httpIsValid(response)
 }
 
-func setCommonHeaders(cli Client, request *http.Request) {
+func (cli Client) setCommonHeaders(request *http.Request) {
 	request.Header.Set("Accept", "application/json")
 	request.SetBasicAuth(cli.Username, cli.Password)
 }


### PR DESCRIPTION
As model structs can be used across multiple features, not only by this CLI tool but for maybe other tools that can take advantage of having a unified model in Go, this PR consolidate all model classes on a dedicated package, while keeping the existing functionality.