### PR TITLE
CLI commands for manipulating nodes (Issue #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following features have been implemented:
 * Reload configuration of OpenNMS daemons
 * Enumerate collected resources and metrics (replacing `resourcecli`)
 * Manually manage the inventory (bypassing the provisioning system), useful when it is not possible to use Provisioning or Auto-Discover.
-* Preliminar support for searching entities (work in progress)
+* Support for searching entities using [FIQL](https://fiql-parser.readthedocs.io/en/stable/usage.html) (work in progress)
 
 The reason for implementing a CLI in `Go` is that the generated binaries are self-contained, and for the first time, Windows users will be able to control OpenNMS from the command line. For example, `provision.pl` or `send-events.pl` rely on having Perl installed with some additional dependencies, which can be complicated on the environment where this is either hard or impossible to have.
 
@@ -151,8 +151,6 @@ password: demo
 Make sure to protect the file, as the credentials are on plain text.
 
 ## Upcoming features
-
-* Search for entities. The idea is to provide a way to build a search expression that will be translated into a [FIQL](https://fiql-parser.readthedocs.io/en/stable/usage.html) expression and use the ReST API v2 of OpenNMS to search for events, alarms, nodes, etc.
 
 * Visualize tabular data with pagination (nodes, events, alarms, outages, notifications).
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following features have been implemented:
 * Send events to OpenNMS (replacing `send-event.pl`)
 * Reload configuration of OpenNMS daemons
 * Enumerate collected resources and metrics (replacing `resourcecli`)
+* Manually manage the inventory (bypassing the provisioning system), useful when it is not possible to use Provisioning or Auto-Discover.
 * Preliminar support for searching entities (work in progress)
 
 The reason for implementing a CLI in `Go` is that the generated binaries are self-contained, and for the first time, Windows users will be able to control OpenNMS from the command line. For example, `provision.pl` or `send-events.pl` rely on having Perl installed with some additional dependencies, which can be complicated on the environment where this is either hard or impossible to have.
@@ -156,5 +157,3 @@ Make sure to protect the file, as the credentials are on plain text.
 * Visualize tabular data with pagination (nodes, events, alarms, outages, notifications).
 
 * Configure scheduled outages.
-
-* Manually build the inventory (when using Provisioning or Auto-Discover are not possible).

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -42,5 +42,5 @@ type NodesAPI interface {
 	DeleteCategory(nodeCriteria string, category string) error
 
 	GetAssetRecord(nodeCriteria string) (*model.OnmsAssetRecord, error)
-	SetAssetRecord(nodeCriteria string, record *model.OnmsAssetRecord) error
+	SetAssetField(nodeCriteria string, field string, value string) error
 }

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -28,8 +28,6 @@ type NodesAPI interface {
 	SetSnmpInterface(nodeCriteria string, intf *model.OnmsSnmpInterface) error
 	DeleteSnmpInterface(nodeCriteria string, ifIndex int) error
 
-	LinkInterfaces(nodeCriteria string, ifIndex int, ipAddress string) error
-
 	GetMonitoredServices(nodeCriteria string, ipAddress string) (*model.OnmsMonitoredServiceList, error)
 
 	GetMonitoredService(nodeCriteria string, ipAddress string, service string) (*model.OnmsMonitoredService, error)

--- a/api/rest.go
+++ b/api/rest.go
@@ -6,7 +6,8 @@ import "net/http"
 type RestAPI interface {
 	Get(path string) ([]byte, error)
 	Post(path string, jsonBytes []byte) error
-	PostRaw(path string, jsonBytes []byte) (*http.Response, error)
+	PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error)
 	Delete(path string) error
 	Put(path string, dataBytes []byte, contentType string) error
+	IsValid(response *http.Response) error
 }

--- a/cli/nodes/assets.go
+++ b/cli/nodes/assets.go
@@ -1,0 +1,129 @@
+package nodes
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/OpenNMS/onmsctl/model"
+	"github.com/OpenNMS/onmsctl/rest"
+	"github.com/OpenNMS/onmsctl/services"
+	"github.com/urfave/cli"
+
+	"gopkg.in/yaml.v2"
+)
+
+// AssetsCliCommand the CLI command to manage nodes
+var AssetsCliCommand = cli.Command{
+	Name:  "assets",
+	Usage: "Manage Assets Record",
+	Subcommands: []cli.Command{
+		{
+			Name:      "list",
+			Usage:     "Lists all the assets for a given node",
+			ArgsUsage: "<nodeId|foreignSource:foreignID>",
+			Action:    getAssets,
+		},
+		{
+			Name:   "enum",
+			Usage:  "Enumerates the available asset fields",
+			Action: getFields,
+		},
+		{
+			Name:      "set",
+			Usage:     "Adds or updates an asset field for a given node",
+			ArgsUsage: "<nodeId|foreignSource:foreignID> <fieldName> <fieldValue>",
+			Action:    addAssetField,
+		},
+		{
+			Name:      "delete",
+			Usage:     "Deletes an existing asset field from a given node (cannot be undone)",
+			ArgsUsage: "<nodeId|foreignSource:foreignID> <fieldName>",
+			Action:    deleteAssetField,
+		},
+	},
+}
+
+func getFields(c *cli.Context) error {
+	fields := getAvailableFields()
+	for _, f := range fields {
+		fmt.Printf("%s\n", f)
+	}
+	return nil
+}
+
+func getAssets(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	record, err := services.GetNodesAPI(rest.Instance).GetAssetRecord(criteria)
+	if err != nil {
+		return err
+	}
+	text, _ := yaml.Marshal(record)
+	fmt.Println(string(text))
+	return nil
+}
+
+func deleteAssetField(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	field := c.Args().Get(1)
+	if field == "" {
+		return fmt.Errorf("field name is required")
+	}
+	return setAssetField(criteria, field, "")
+}
+
+func addAssetField(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	field := c.Args().Get(1)
+	if field == "" {
+		return fmt.Errorf("field name is required")
+	}
+	value := c.Args().Get(2)
+	if value == "" {
+		return fmt.Errorf("field value is required")
+	}
+	return setAssetField(criteria, field, value)
+}
+
+func setAssetField(criteria string, field string, value string) error {
+	if !isValidField(field) {
+		return fmt.Errorf("Invalid field %s", field)
+	}
+	record, err := services.GetNodesAPI(rest.Instance).GetAssetRecord(criteria)
+	if err != nil {
+		return err
+	}
+	reflect.ValueOf(record).Elem().FieldByName(field).SetString(value)
+	return services.GetNodesAPI(rest.Instance).SetAssetRecord(criteria, record)
+}
+
+func getAvailableFields() []string {
+	r := &model.OnmsAssetRecord{}
+	s := reflect.ValueOf(r).Elem()
+	typeOfT := s.Type()
+	fields := make([]string, 0)
+	for i := 0; i < s.NumField(); i++ {
+		f := typeOfT.Field(i).Name
+		if f != "" && f != "ID" && f != "XMLName" {
+			fields = append(fields, typeOfT.Field(i).Name)
+		}
+	}
+	return fields
+}
+
+func isValidField(field string) bool {
+	for _, f := range getAvailableFields() {
+		if f == field {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/nodes/categories.go
+++ b/cli/nodes/categories.go
@@ -1,0 +1,84 @@
+package nodes
+
+import (
+	"fmt"
+
+	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
+	"github.com/OpenNMS/onmsctl/rest"
+	"github.com/OpenNMS/onmsctl/services"
+	"github.com/urfave/cli"
+)
+
+// CategoriesCliCommand the CLI command to manage nodes
+var CategoriesCliCommand = cli.Command{
+	Name:  "categories",
+	Usage: "Manage Surveillance or Node Categories",
+	Subcommands: []cli.Command{
+		{
+			Name:      "list",
+			Usage:     "Lists all the categories for a given node",
+			ArgsUsage: "<nodeId|foreignSource:foreignID>",
+			Action:    getCategories,
+		},
+		{
+			Name:      "add",
+			Usage:     "Add a new category to a given node",
+			ArgsUsage: "<nodeId|foreignSource:foreignID> <categoryName>",
+			Action:    addCategory,
+		},
+		{
+			Name:      "delete",
+			Usage:     "Deletes an existing category from a given node (cannot be undone)",
+			ArgsUsage: "<nodeId|foreignSource:foreignID> <category>",
+			Action:    deleteCategory,
+		},
+	},
+}
+
+func getCategories(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	list, err := services.GetNodesAPI(rest.Instance).GetCategories(criteria)
+	if err != nil {
+		return err
+	}
+	if len(list) == 0 {
+		fmt.Println("There are no categories")
+		return nil
+	}
+	writer := common.NewTableWriter()
+	fmt.Fprintln(writer, "ID\tName")
+	for _, cat := range list {
+		fmt.Fprintf(writer, "%d\t%s\n", cat.ID, cat.Name)
+	}
+	writer.Flush()
+	return nil
+}
+
+func deleteCategory(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	name := c.Args().Get(1)
+	if name == "" {
+		return fmt.Errorf("category name is required")
+	}
+	return services.GetNodesAPI(rest.Instance).DeleteCategory(criteria, name)
+}
+
+func addCategory(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	name := c.Args().Get(1)
+	if name == "" {
+		return fmt.Errorf("category name is required")
+	}
+	category := &model.OnmsCategory{Name: name}
+	return services.GetNodesAPI(rest.Instance).AddCategory(criteria, category)
+}

--- a/cli/nodes/ipinterfaces.go
+++ b/cli/nodes/ipinterfaces.go
@@ -32,7 +32,7 @@ var IPInterfacesCliCommand = cli.Command{
 					Usage: "IP Address",
 				},
 				cli.StringFlag{
-					Name:  "hostname, h",
+					Name:  "hostname, n",
 					Usage: "Hostname or FQDN",
 				},
 				cli.StringFlag{
@@ -123,7 +123,7 @@ func getIPInterfaces(c *cli.Context) error {
 	writer := common.NewTableWriter()
 	fmt.Fprintln(writer, "ID\tIP Address\tifIndex\tIs Managed\tSNMP Primary\tIs Down")
 	for _, n := range list.Interfaces {
-		fmt.Fprintf(writer, "%d\t%s\t%d\t%s\t%s\t%v\n", n.ID, n.IPAddress, n.IfIndex, n.IsManaged, n.SnmpPrimary, n.IsDown)
+		fmt.Fprintf(writer, "%s\t%s\t%d\t%s\t%s\t%v\n", n.ID, n.IPAddress, n.IfIndex, n.IsManaged, n.SnmpPrimary, n.IsDown)
 	}
 	writer.Flush()
 	return nil
@@ -135,7 +135,7 @@ func deleteIPInterface(c *cli.Context) error {
 		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
 	}
 	ipaddr := c.Args().Get(1)
-	if criteria == "" {
+	if ipaddr == "" {
 		return fmt.Errorf("Interface IP Address is required")
 	}
 	return services.GetNodesAPI(rest.Instance).DeleteIPInterface(criteria, ipaddr)
@@ -191,7 +191,7 @@ func setInterfaceMetadata(c *cli.Context) error {
 		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
 	}
 	ipaddr := c.Args().Get(1)
-	if criteria == "" {
+	if ipaddr == "" {
 		return fmt.Errorf("Interface IP Address is required")
 	}
 	meta := model.MetaData{
@@ -211,7 +211,7 @@ func deleteInterfaceMetadata(c *cli.Context) error {
 		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
 	}
 	ipaddr := c.Args().Get(1)
-	if criteria == "" {
+	if ipaddr == "" {
 		return fmt.Errorf("Interface IP Address is required")
 	}
 	ctx := c.String("context")

--- a/cli/nodes/ipinterfaces.go
+++ b/cli/nodes/ipinterfaces.go
@@ -1,0 +1,226 @@
+package nodes
+
+import (
+	"fmt"
+
+	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
+	"github.com/OpenNMS/onmsctl/rest"
+	"github.com/OpenNMS/onmsctl/services"
+	"github.com/urfave/cli"
+)
+
+// IPInterfacesCliCommand the CLI command to manage nodes
+var IPInterfacesCliCommand = cli.Command{
+	Name:  "ipInterfaces",
+	Usage: "Manage IP Interfaces",
+	Subcommands: []cli.Command{
+		{
+			Name:      "list",
+			Usage:     "Lists all the IP interfaces for a given node",
+			ArgsUsage: "<nodeId|foreignSource:foreignID>",
+			Action:    getIPInterfaces,
+		},
+		{
+			Name:      "add",
+			Usage:     "Add a new IP interface to a given node",
+			ArgsUsage: "<nodeId|foreignSource:foreignID>",
+			Action:    addIPInterface,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "ipAddr, i",
+					Usage: "IP Address",
+				},
+				cli.StringFlag{
+					Name:  "hostname, h",
+					Usage: "Hostname or FQDN",
+				},
+				cli.StringFlag{
+					Name:  "isManaged, m",
+					Usage: "Managed Flag",
+				},
+				cli.StringFlag{
+					Name:  "snmpPrimary, p",
+					Usage: "SNMP Primary Flag",
+				},
+				cli.IntFlag{
+					Name:  "ifIndex, I",
+					Usage: "ifIndex of the existing SNMP interface to associte with the IP interface",
+				},
+			},
+		},
+		{
+			Name:      "delete",
+			Usage:     "Deletes an existing IP interface from a given node (cannot be undone)",
+			ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress>",
+			Action:    deleteIPInterface,
+		},
+		{
+			Name:  "metadata",
+			Usage: "Manage interface-level metadata",
+			Subcommands: []cli.Command{
+				{
+					Name:      "list",
+					Usage:     "Lists all the interface-level metadata",
+					Action:    listInterfaceMetadata,
+					ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress>",
+				},
+				{
+					Name:      "set",
+					Usage:     "Adds or updates a interface-level metadata entry",
+					Action:    setInterfaceMetadata,
+					ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress>",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "context, c",
+							Usage: "Metadata Context",
+						},
+						cli.StringFlag{
+							Name:  "key, k",
+							Usage: "Metadata Key",
+						},
+						cli.StringFlag{
+							Name:  "value, v",
+							Usage: "Metadata Value",
+						},
+					},
+				},
+				{
+					Name:      "delete",
+					Usage:     "Deletes an existing interface-level metadata entry",
+					Action:    deleteInterfaceMetadata,
+					ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress>",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "context, c",
+							Usage: "Metadata Context",
+						},
+						cli.StringFlag{
+							Name:  "key, k",
+							Usage: "Metadata Key",
+						},
+					},
+				},
+			},
+		},
+		ServicesCliCommand,
+	},
+}
+
+func getIPInterfaces(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	list, err := services.GetNodesAPI(rest.Instance).GetIPInterfaces(criteria)
+	if err != nil {
+		return err
+	}
+	if len(list.Interfaces) == 0 {
+		fmt.Println("There are no IP interfaces")
+		return nil
+	}
+	writer := common.NewTableWriter()
+	fmt.Fprintln(writer, "ID\tIP Address\tifIndex\tIs Managed\tSNMP Primary\tIs Down")
+	for _, n := range list.Interfaces {
+		fmt.Fprintf(writer, "%d\t%s\t%d\t%s\t%s\t%v\n", n.ID, n.IPAddress, n.IfIndex, n.IsManaged, n.SnmpPrimary, n.IsDown)
+	}
+	writer.Flush()
+	return nil
+}
+
+func deleteIPInterface(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ipaddr := c.Args().Get(1)
+	if criteria == "" {
+		return fmt.Errorf("Interface IP Address is required")
+	}
+	return services.GetNodesAPI(rest.Instance).DeleteIPInterface(criteria, ipaddr)
+}
+
+func addIPInterface(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ip := &model.OnmsIPInterface{
+		IPAddress:   c.String("ipAddr"),
+		HostName:    c.String("hostname"),
+		IsManaged:   c.String("isManaged"),
+		SnmpPrimary: c.String("snmpInterface"),
+		IfIndex:     c.Int("ifIndex"),
+	}
+	if err := ip.Validate(); err != nil {
+		return err
+	}
+	return services.GetNodesAPI(rest.Instance).SetIPInterface(criteria, ip)
+}
+
+func listInterfaceMetadata(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ipaddr := c.Args().Get(1)
+	if criteria == "" {
+		return fmt.Errorf("Interface IP Address is required")
+	}
+	meta, err := services.GetNodesAPI(rest.Instance).GetIPInterfaceMetadata(criteria, ipaddr)
+	if err != nil {
+		return err
+	}
+	if len(meta) == 0 {
+		fmt.Println("There is no metadata")
+		return nil
+	}
+	writer := common.NewTableWriter()
+	fmt.Fprintln(writer, "Context\tKey\tValue")
+	for _, m := range meta {
+		fmt.Fprintf(writer, "%s\t%s\t%s\n", m.Context, m.Key, m.Value)
+	}
+	writer.Flush()
+	return nil
+}
+
+func setInterfaceMetadata(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ipaddr := c.Args().Get(1)
+	if criteria == "" {
+		return fmt.Errorf("Interface IP Address is required")
+	}
+	meta := model.MetaData{
+		Context: c.String("context"),
+		Key:     c.String("key"),
+		Value:   c.String("value"),
+	}
+	if err := meta.Validate(); err != nil {
+		return err
+	}
+	return services.GetNodesAPI(rest.Instance).SetIPInterfaceMetadata(criteria, ipaddr, meta)
+}
+
+func deleteInterfaceMetadata(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ipaddr := c.Args().Get(1)
+	if criteria == "" {
+		return fmt.Errorf("Interface IP Address is required")
+	}
+	ctx := c.String("context")
+	if ctx == "" {
+		return fmt.Errorf("Context is required")
+	}
+	key := c.String("key")
+	if key == "" {
+		return fmt.Errorf("Key is required")
+	}
+	return services.GetNodesAPI(rest.Instance).DeleteIPInterfaceMetadata(criteria, ipaddr, ctx, key)
+}

--- a/cli/nodes/nodes.go
+++ b/cli/nodes/nodes.go
@@ -37,14 +37,6 @@ var CliCommand = cli.Command{
 					Usage: "Node Minion Location",
 				},
 				cli.StringFlag{
-					Name:  "foreignSource, f",
-					Usage: "Foreign Source",
-				},
-				cli.StringFlag{
-					Name:  "foreignID, i",
-					Usage: "Foreign ID",
-				},
-				cli.StringFlag{
 					Name:  "sysOID, so",
 					Usage: "SNMP System Object ID",
 				},
@@ -169,8 +161,6 @@ func addNode(c *cli.Context) error {
 	n := &model.OnmsNode{
 		Label:          c.String("label"),
 		Location:       c.String("location"),
-		ForeignSource:  c.String("foreignSource"),
-		ForeignID:      c.String("foreignID"),
 		SysObjectID:    c.String("sysOID"),
 		SysName:        c.String("sysName"),
 		SysDescription: c.String("sysDescr"),

--- a/cli/nodes/nodes.go
+++ b/cli/nodes/nodes.go
@@ -1,0 +1,91 @@
+package nodes
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
+	"github.com/OpenNMS/onmsctl/rest"
+	"github.com/OpenNMS/onmsctl/services"
+	"github.com/urfave/cli"
+	"gopkg.in/yaml.v2"
+)
+
+// CliCommand the CLI command to manage nodes
+var CliCommand = cli.Command{
+	Name:        "nodes",
+	Usage:       "Manage OpenNMS Nodes / Inventory",
+	Description: "Manage OpenNMS Nodes / Inventory\n   The recommended way to populate the inventory is via Provisioning Requisitions or Auto-Discover.\n   When neither of those methods are possible, you can manually build the inventory using this sub-command.\n   It is expected a YAML file with 'nodes' as root tag and an array of elements inside of it.",
+	Subcommands: []cli.Command{
+		{
+			Name:   "list",
+			Usage:  "Lists all the nodes",
+			Action: getNodes,
+		},
+		{
+			Name:   "apply",
+			Usage:  "Creates a set of nodes from a external file",
+			Action: addNodes,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "file, f",
+					Usage: "External file (use '-' for STDIN Pipe)",
+				},
+			},
+			ArgsUsage: "<content>",
+		},
+		{
+			Name:      "delete",
+			Usage:     "Deletes an existing node (cannot be undone)",
+			ArgsUsage: "<nodeId|foreignSource:foreignID>",
+			Action:    deleteNode,
+		},
+	},
+}
+
+func getNodes(c *cli.Context) error {
+	list, err := services.GetNodesAPI(rest.Instance).GetNodes()
+	if err != nil {
+		return err
+	}
+	if len(list.Nodes) == 0 {
+		fmt.Println("There are no nodes")
+		return nil
+	}
+	writer := common.NewTableWriter()
+	fmt.Fprintln(writer, "Node ID\tNode Label\tForeign Source\tForeign ID\tSNMP sysObjectID")
+	for _, n := range list.Nodes {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", n.ID, n.Label, n.ForeignSource, n.ForeignID, n.SysObjectID)
+	}
+	writer.Flush()
+	return nil
+}
+
+func deleteNode(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	return services.GetNodesAPI(rest.Instance).DeleteNode(criteria)
+}
+
+func addNodes(c *cli.Context) error {
+	list := &model.OnmsNodeList{}
+	data, err := common.ReadInput(c, 0)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(data, list)
+	if err != nil {
+		return err
+	}
+	api := services.GetNodesAPI(rest.Instance)
+	for _, n := range list.Nodes {
+		err := api.AddNode(&n)
+		if err != nil {
+			log.Printf("[ERROR] %v\n", err)
+		}
+	}
+	return nil
+}

--- a/cli/nodes/services.go
+++ b/cli/nodes/services.go
@@ -135,16 +135,19 @@ func addService(c *cli.Context) error {
 	if criteria == "" {
 		return fmt.Errorf("Interface IP Address is required")
 	}
-
-	svc := &model.OnmsMonitoredService{
+	svc := c.Args().Get(2)
+	if criteria == "" {
+		return fmt.Errorf("Monitored Service Name is required")
+	}
+	service := &model.OnmsMonitoredService{
 		ServiceType: &model.OnmsServiceType{
-			Name: c.String("name"),
+			Name: svc,
 		},
 	}
-	if err := svc.Validate(); err != nil {
+	if err := service.Validate(); err != nil {
 		return err
 	}
-	return services.GetNodesAPI(rest.Instance).SetMonitoredService(criteria, ipaddr, svc)
+	return services.GetNodesAPI(rest.Instance).SetMonitoredService(criteria, ipaddr, service)
 }
 
 func listServiceMetadata(c *cli.Context) error {
@@ -153,11 +156,11 @@ func listServiceMetadata(c *cli.Context) error {
 		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
 	}
 	ipaddr := c.Args().Get(1)
-	if criteria == "" {
+	if ipaddr == "" {
 		return fmt.Errorf("Interface IP Address is required")
 	}
 	svc := c.Args().Get(2)
-	if criteria == "" {
+	if svc == "" {
 		return fmt.Errorf("Monitored Service Name is required")
 	}
 	meta, err := services.GetNodesAPI(rest.Instance).GetMonitoredServiceMetadata(criteria, ipaddr, svc)
@@ -183,11 +186,11 @@ func setServiceMetadata(c *cli.Context) error {
 		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
 	}
 	ipaddr := c.Args().Get(1)
-	if criteria == "" {
+	if ipaddr == "" {
 		return fmt.Errorf("Interface IP Address is required")
 	}
 	svc := c.Args().Get(2)
-	if criteria == "" {
+	if svc == "" {
 		return fmt.Errorf("Monitored Service Name is required")
 	}
 	meta := model.MetaData{
@@ -207,11 +210,11 @@ func deleteServiceMetadata(c *cli.Context) error {
 		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
 	}
 	ipaddr := c.Args().Get(1)
-	if criteria == "" {
+	if ipaddr == "" {
 		return fmt.Errorf("Interface IP Address is required")
 	}
 	svc := c.Args().Get(2)
-	if criteria == "" {
+	if svc == "" {
 		return fmt.Errorf("Monitored Service Name is required")
 	}
 	ctx := c.String("context")

--- a/cli/nodes/services.go
+++ b/cli/nodes/services.go
@@ -1,0 +1,226 @@
+package nodes
+
+import (
+	"fmt"
+
+	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
+	"github.com/OpenNMS/onmsctl/rest"
+	"github.com/OpenNMS/onmsctl/services"
+	"github.com/urfave/cli"
+)
+
+// ServicesCliCommand the CLI command to manage nodes
+var ServicesCliCommand = cli.Command{
+	Name:  "services",
+	Usage: "Manage Monitores Services",
+	Subcommands: []cli.Command{
+		{
+			Name:      "list",
+			Usage:     "Lists all the monitoring services for a given IP interface on a given node",
+			ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress>",
+			Action:    getServices,
+		},
+		{
+			Name:      "add",
+			Usage:     "Add a new monitored service a given IP interface on a given node",
+			ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress> <serviceName>",
+			Action:    addService,
+		},
+		{
+			Name:      "delete",
+			Usage:     "Deletes an existing monitored service from a given IP interface on a given node (cannot be undone)",
+			ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress> <serviceName>",
+			Action:    deleteService,
+		},
+		{
+			Name:  "metadata",
+			Usage: "Manage service-level metadata",
+			Subcommands: []cli.Command{
+				{
+					Name:      "list",
+					Usage:     "Lists all the service-level metadata",
+					Action:    listServiceMetadata,
+					ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress> <serviceName>",
+				},
+				{
+					Name:      "set",
+					Usage:     "Adds or updates a service-level metadata entry",
+					Action:    setServiceMetadata,
+					ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress> <serviceName>",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "context, c",
+							Usage: "Metadata Context",
+						},
+						cli.StringFlag{
+							Name:  "key, k",
+							Usage: "Metadata Key",
+						},
+						cli.StringFlag{
+							Name:  "value, v",
+							Usage: "Metadata Value",
+						},
+					},
+				},
+				{
+					Name:      "delete",
+					Usage:     "Deletes an existing service-level metadata entry",
+					Action:    deleteServiceMetadata,
+					ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress> <serviceName>",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "context, c",
+							Usage: "Metadata Context",
+						},
+						cli.StringFlag{
+							Name:  "key, k",
+							Usage: "Metadata Key",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func getServices(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ipaddr := c.Args().Get(1)
+	if criteria == "" {
+		return fmt.Errorf("Interface IP Address is required")
+	}
+	list, err := services.GetNodesAPI(rest.Instance).GetMonitoredServices(criteria, ipaddr)
+	if err != nil {
+		return err
+	}
+	if len(list.Services) == 0 {
+		fmt.Println("There are no monitores services")
+		return nil
+	}
+	writer := common.NewTableWriter()
+	fmt.Fprintln(writer, "ID\tService Name\tIs Down\tLast Good\tLast Fail")
+	for _, n := range list.Services {
+		fmt.Fprintf(writer, "%d\t%s\t%v\t%s\t%s\n", n.ID, n.ServiceType.Name, n.IsDown, n.LastGood, n.LastFail)
+	}
+	writer.Flush()
+	return nil
+}
+
+func deleteService(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ipaddr := c.Args().Get(1)
+	if criteria == "" {
+		return fmt.Errorf("Interface IP Address is required")
+	}
+	svc := c.Args().Get(2)
+	if criteria == "" {
+		return fmt.Errorf("Monitored Service Name is required")
+	}
+	return services.GetNodesAPI(rest.Instance).DeleteMonitoredService(criteria, ipaddr, svc)
+}
+
+func addService(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ipaddr := c.Args().Get(1)
+	if criteria == "" {
+		return fmt.Errorf("Interface IP Address is required")
+	}
+
+	svc := &model.OnmsMonitoredService{
+		ServiceType: &model.OnmsServiceType{
+			Name: c.String("name"),
+		},
+	}
+	if err := svc.Validate(); err != nil {
+		return err
+	}
+	return services.GetNodesAPI(rest.Instance).SetMonitoredService(criteria, ipaddr, svc)
+}
+
+func listServiceMetadata(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ipaddr := c.Args().Get(1)
+	if criteria == "" {
+		return fmt.Errorf("Interface IP Address is required")
+	}
+	svc := c.Args().Get(2)
+	if criteria == "" {
+		return fmt.Errorf("Monitored Service Name is required")
+	}
+	meta, err := services.GetNodesAPI(rest.Instance).GetMonitoredServiceMetadata(criteria, ipaddr, svc)
+	if err != nil {
+		return err
+	}
+	if len(meta) == 0 {
+		fmt.Println("There is no metadata")
+		return nil
+	}
+	writer := common.NewTableWriter()
+	fmt.Fprintln(writer, "Context\tKey\tValue")
+	for _, m := range meta {
+		fmt.Fprintf(writer, "%s\t%s\t%s\n", m.Context, m.Key, m.Value)
+	}
+	writer.Flush()
+	return nil
+}
+
+func setServiceMetadata(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ipaddr := c.Args().Get(1)
+	if criteria == "" {
+		return fmt.Errorf("Interface IP Address is required")
+	}
+	svc := c.Args().Get(2)
+	if criteria == "" {
+		return fmt.Errorf("Monitored Service Name is required")
+	}
+	meta := model.MetaData{
+		Context: c.String("context"),
+		Key:     c.String("key"),
+		Value:   c.String("value"),
+	}
+	if err := meta.Validate(); err != nil {
+		return err
+	}
+	return services.GetNodesAPI(rest.Instance).SetMonitoredServiceMetadata(criteria, ipaddr, svc, meta)
+}
+
+func deleteServiceMetadata(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	ipaddr := c.Args().Get(1)
+	if criteria == "" {
+		return fmt.Errorf("Interface IP Address is required")
+	}
+	svc := c.Args().Get(2)
+	if criteria == "" {
+		return fmt.Errorf("Monitored Service Name is required")
+	}
+	ctx := c.String("context")
+	if ctx == "" {
+		return fmt.Errorf("Context is required")
+	}
+	key := c.String("key")
+	if key == "" {
+		return fmt.Errorf("Key is required")
+	}
+	return services.GetNodesAPI(rest.Instance).DeleteMonitoredServiceMetadata(criteria, ipaddr, svc, ctx, key)
+}

--- a/cli/nodes/snmpinterfaces.go
+++ b/cli/nodes/snmpinterfaces.go
@@ -60,6 +60,14 @@ var SnmpInterfacesCliCommand = cli.Command{
 					Name:  "ifAlias, a",
 					Usage: "The IF-MIB::ifAlias",
 				},
+				cli.BoolTFlag{
+					Name:  "collect",
+					Usage: "flag to collect performance metrics via SNMP Collector",
+				},
+				cli.BoolFlag{
+					Name:  "poll",
+					Usage: "flag to poll status via SNMP Interface Poller",
+				},
 			},
 		},
 		{
@@ -123,6 +131,16 @@ func addSnmpInterface(c *cli.Context) error {
 		IfName:        c.String("ifName"),
 		IfDescr:       c.String("ifDescr"),
 		IfAlias:       c.String("ifAlias"),
+	}
+	if c.BoolT("collect") {
+		snmp.CollectFlag = "UC"
+	} else {
+		snmp.CollectFlag = "UN"
+	}
+	if c.Bool("poll") {
+		snmp.PollFlag = "P"
+	} else {
+		snmp.PollFlag = "N"
 	}
 	if err := snmp.Validate(); err != nil {
 		return err

--- a/cli/nodes/snmpinterfaces.go
+++ b/cli/nodes/snmpinterfaces.go
@@ -34,11 +34,11 @@ var SnmpInterfacesCliCommand = cli.Command{
 				},
 				cli.IntFlag{
 					Name:  "ifOper, o",
-					Usage: "The IF-MIB::ifOperStatus",
+					Usage: "The IF-MIB::ifOperStatus (1:up, 2:down, 3:testing, 4:unknown, 5:dormant, 6:notPresent, 7:lowerLayerDown)",
 				},
 				cli.IntFlag{
 					Name:  "ifAdmin, A",
-					Usage: "The IF-MIB::ifAdminStatus",
+					Usage: "The IF-MIB::ifAdminStatus (1:up, 2:down, 3:testing)",
 				},
 				cli.Int64Flag{
 					Name:  "ifSpeed, s",
@@ -59,6 +59,10 @@ var SnmpInterfacesCliCommand = cli.Command{
 				cli.StringFlag{
 					Name:  "ifAlias, a",
 					Usage: "The IF-MIB::ifAlias",
+				},
+				cli.StringFlag{
+					Name:  "physAddress, p",
+					Usage: "The IF-MIB::ifPhysAddress (MAC Address)",
 				},
 				cli.BoolTFlag{
 					Name:  "collect",
@@ -131,6 +135,7 @@ func addSnmpInterface(c *cli.Context) error {
 		IfName:        c.String("ifName"),
 		IfDescr:       c.String("ifDescr"),
 		IfAlias:       c.String("ifAlias"),
+		PhysAddress:   c.String("physAddress"),
 	}
 	if c.BoolT("collect") {
 		snmp.CollectFlag = "UC"

--- a/cli/nodes/snmpinterfaces.go
+++ b/cli/nodes/snmpinterfaces.go
@@ -1,0 +1,131 @@
+package nodes
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/OpenNMS/onmsctl/common"
+	"github.com/OpenNMS/onmsctl/model"
+	"github.com/OpenNMS/onmsctl/rest"
+	"github.com/OpenNMS/onmsctl/services"
+	"github.com/urfave/cli"
+)
+
+// SnmpInterfacesCliCommand the CLI command to manage nodes
+var SnmpInterfacesCliCommand = cli.Command{
+	Name:  "snmpInterfaces",
+	Usage: "Manage SNMP Interfaces",
+	Subcommands: []cli.Command{
+		{
+			Name:      "list",
+			Usage:     "Lists all the SNMP interfaces for a given node",
+			ArgsUsage: "<nodeId|foreignSource:foreignID>",
+			Action:    getSnmpInterfaces,
+		},
+		{
+			Name:      "add",
+			Usage:     "Add a new SNMP interface to a given node",
+			ArgsUsage: "<nodeId|foreignSource:foreignID>",
+			Action:    addSnmpInterface,
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  "ifIndex, i",
+					Usage: "The IF-MIB::ifIndex",
+				},
+				cli.IntFlag{
+					Name:  "ifOper, o",
+					Usage: "The IF-MIB::ifOperStatus",
+				},
+				cli.IntFlag{
+					Name:  "ifAdmin, A",
+					Usage: "The IF-MIB::ifAdminStatus",
+				},
+				cli.Int64Flag{
+					Name:  "ifSpeed, s",
+					Usage: "The IF-MIB::ifSpeed expressed in bits per second",
+				},
+				cli.IntFlag{
+					Name:  "ifType, t",
+					Usage: "The IF-MIB::ifType",
+				},
+				cli.StringFlag{
+					Name:  "ifName, n",
+					Usage: "The IF-MIB::ifName",
+				},
+				cli.StringFlag{
+					Name:  "ifDescr, d",
+					Usage: "The IF-MIB::ifDescr",
+				},
+				cli.StringFlag{
+					Name:  "ifAlias, a",
+					Usage: "The IF-MIB::ifAlias",
+				},
+			},
+		},
+		{
+			Name:      "delete",
+			Usage:     "Deletes an existing SNMP interface from a given node (cannot be undone)",
+			ArgsUsage: "<nodeId|foreignSource:foreignID> <ifIndex>",
+			Action:    deleteSnmpInterface,
+		},
+	},
+}
+
+func getSnmpInterfaces(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	list, err := services.GetNodesAPI(rest.Instance).GetSnmpInterfaces(criteria)
+	if err != nil {
+		return err
+	}
+	if len(list.Interfaces) == 0 {
+		fmt.Println("There are no SNMP interfaces")
+		return nil
+	}
+	writer := common.NewTableWriter()
+	fmt.Fprintln(writer, "ID\tifIndex\tifDescr\tifName\tifAlias\tifType\tifOperStatus\tifAdminStatus")
+	for _, n := range list.Interfaces {
+		fmt.Fprintf(writer, "%d\t%d\t%s\t%s\t%s\t%d\t%d\t%d\n", n.ID, n.IfIndex, n.IfDescr, n.IfName, n.IfAlias, n.IfType, n.IfOperStatus, n.IfAdminStatus)
+	}
+	writer.Flush()
+	return nil
+}
+
+func deleteSnmpInterface(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	idx := c.Args().Get(1)
+	if idx == "" {
+		return fmt.Errorf("ifIndex is required")
+	}
+	ifIndex, err := strconv.Atoi(idx)
+	if err != nil {
+		return fmt.Errorf("Cannot parse ifIndex: %s", idx)
+	}
+	return services.GetNodesAPI(rest.Instance).DeleteSnmpInterface(criteria, ifIndex)
+}
+
+func addSnmpInterface(c *cli.Context) error {
+	criteria := c.Args().Get(0)
+	if criteria == "" {
+		return fmt.Errorf("Either the nodeID or the foreignSource:foreignID combination is required")
+	}
+	snmp := &model.OnmsSnmpInterface{
+		IfIndex:       c.Int("ifIndex"),
+		IfOperStatus:  c.Int("ifOper"),
+		IfAdminStatus: c.Int("ifAdmin"),
+		IfType:        c.Int("ifType"),
+		IfSpeed:       c.Int64("ifSpeed"),
+		IfName:        c.String("ifName"),
+		IfDescr:       c.String("ifDescr"),
+		IfAlias:       c.String("ifAlias"),
+	}
+	if err := snmp.Validate(); err != nil {
+		return err
+	}
+	return services.GetNodesAPI(rest.Instance).SetSnmpInterface(criteria, snmp)
+}

--- a/cli/provisioning/provisioning.go
+++ b/cli/provisioning/provisioning.go
@@ -8,7 +8,7 @@ import (
 var CliCommand = cli.Command{
 	Name:      "provision",
 	ShortName: "inv",
-	Usage:     "Manage provisioning / inventory",
+	Usage:     "Manage Provisioning / Inventory",
 	Subcommands: []cli.Command{
 		RequisitionsCliCommand,
 		NodesCliCommand,

--- a/model/nodes.go
+++ b/model/nodes.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/xml"
 	"fmt"
+	"net"
 )
 
 // MetaDataList a list of metadata
@@ -223,6 +224,10 @@ func (obj *OnmsIPInterface) Validate() error {
 	if obj.IPAddress == "" {
 		return fmt.Errorf("IP Address cannot be empty")
 	}
+	ip := net.ParseIP(obj.IPAddress)
+	if ip == nil {
+		return fmt.Errorf("Invalid IP Address: %s", obj.IPAddress)
+	}
 	if obj.SnmpPrimary == "" {
 		obj.SnmpPrimary = "P"
 	}
@@ -319,6 +324,12 @@ func (obj *OnmsSnmpInterface) Validate() error {
 	}
 	if obj.PollFlag == "" {
 		obj.PollFlag = "N"
+	}
+	if obj.PhysAddress != "" {
+		_, err := net.ParseMAC(obj.PhysAddress)
+		if err != nil {
+			return fmt.Errorf("Invalid Physical Address: %v", err)
+		}
 	}
 	return nil
 }

--- a/model/nodes.go
+++ b/model/nodes.go
@@ -246,7 +246,7 @@ type OnmsSnmpInterface struct {
 	ID                      int      `xml:"id,attr,omitempty" json:"id,omitempty" yaml:"id,omitempty"`
 	IfType                  int      `xml:"ifType,omitempty" json:"ifType,omitempty" yaml:"ifType,omitempty"`
 	IfAlias                 string   `xml:"ifAlias,omitempty" json:"ifAlias,omitempty" yaml:"ifAlias,omitempty"`
-	IfIndex                 int      `xml:"ifIndex,omitempty" json:"ifIndex,omitempty" yaml:"ifIndex,omitempty"`
+	IfIndex                 int      `xml:"ifIndex,attr,omitempty" json:"ifIndex,omitempty" yaml:"ifIndex,omitempty"`
 	IfDescr                 string   `xml:"ifDescr,omitempty" json:"ifDescr,omitempty" yaml:"ifDescr,omitempty"`
 	IfName                  string   `xml:"ifName,omitempty" json:"ifName,omitempty" yaml:"ifName,omitempty"`
 	PhysAddress             string   `xml:"physAddress,omitempty" json:"physAddress,omitempty" yaml:"physAddress,omitempty"`

--- a/model/nodes.go
+++ b/model/nodes.go
@@ -5,6 +5,15 @@ import (
 	"fmt"
 )
 
+// MetaDataList a list of metadata
+type MetaDataList struct {
+	XMLName    xml.Name   `xml:"meta-data-list" json:"-" yaml:"-"`
+	Count      int        `xml:"count,attr" json:"count" yaml:"count"`
+	TotalCount int        `xml:"totalCount,attr" json:"totalCount" yaml:"totalCount"`
+	Offset     int        `xml:"offset,attr" json:"offset" yaml:"offset"`
+	Metadata   []MetaData `xml:"meta-data" json:"metaData" yaml:"metadata"`
+}
+
 // MetaData a meta-data entry
 type MetaData struct {
 	XMLName xml.Name `xml:"meta-data" json:"-" yaml:"-"`
@@ -25,6 +34,15 @@ func (obj *MetaData) Validate() error {
 		return fmt.Errorf("Context cannot be empty")
 	}
 	return nil
+}
+
+// OnmsCategoryList a list of metadata
+type OnmsCategoryList struct {
+	XMLName    xml.Name       `xml:"categories" json:"-" yaml:"-"`
+	Count      int            `xml:"count,attr" json:"count" yaml:"count"`
+	TotalCount int            `xml:"totalCount,attr" json:"totalCount" yaml:"totalCount"`
+	Offset     int            `xml:"offset,attr" json:"offset" yaml:"offset"`
+	Categories []OnmsCategory `xml:"category" json:"category" yaml:"categories"`
 }
 
 // OnmsCategory an entity that represents an OpenNMS category
@@ -171,7 +189,7 @@ type OnmsMonitoredServiceList struct {
 // OnmsIPInterface an entity that represents an OpenNMS IP Interface
 type OnmsIPInterface struct {
 	XMLName               xml.Name               `xml:"ipInterface" json:"-" yaml:"-"`
-	ID                    int                    `xml:"id,attr,omitempty" json:"id,omitempty" yaml:"id,omitempty"`
+	ID                    string                 `xml:"id,attr,omitempty" json:"id,omitempty" yaml:"id,omitempty"` // The JSON returns a string instead of an integer
 	NodeID                int                    `xml:"nodeId,omitempty" json:"nodeId,omitempty" yaml:"-,omitempty"`
 	IsManaged             string                 `xml:"isManaged,attr,omitempty" json:"isManaged,omitempty" yaml:"isManaged,omitempty"`
 	IPAddress             string                 `xml:"ipAddress" json:"ipAddress" yaml:"ipAddress"`

--- a/onmsctl.go
+++ b/onmsctl.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OpenNMS/onmsctl/cli/daemon"
 	"github.com/OpenNMS/onmsctl/cli/events"
 	"github.com/OpenNMS/onmsctl/cli/info"
+	"github.com/OpenNMS/onmsctl/cli/nodes"
 	"github.com/OpenNMS/onmsctl/cli/profiles"
 	"github.com/OpenNMS/onmsctl/cli/provisioning"
 	"github.com/OpenNMS/onmsctl/cli/resources"
@@ -17,7 +18,7 @@ import (
 )
 
 var (
-	version = "v1.0.0-beta2"
+	version = "v1.0.0-beta3"
 )
 
 func main() {
@@ -85,6 +86,7 @@ func initCliCommands(app *cli.App) {
 	app.Commands = []cli.Command{
 		info.CliCommand,
 		provisioning.CliCommand,
+		nodes.CliCommand,
 		snmp.CliCommand,
 		events.CliCommand,
 		daemon.CliCommand,

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -104,7 +104,7 @@ func (cli Client) Delete(path string) error {
 // Put sends an HTTP PUT request
 func (cli Client) Put(path string, dataBytes []byte, contentType string) error {
 	if cli.Debug {
-		log.Println("Data to be sent", string(dataBytes))
+		log.Printf("PUT, Path: %s, Type: %s, Data: %s", cli.URL+path, contentType, string(dataBytes))
 	}
 	request, err := cli.buildRequest(http.MethodPut, cli.URL+path, bytes.NewBuffer(dataBytes))
 	if err != nil {

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -40,6 +40,9 @@ func (cli Client) getHTTPClient() *http.Client {
 
 // Get sends an HTTP GET request
 func (cli Client) Get(path string) ([]byte, error) {
+	if cli.Debug {
+		log.Printf("GET, Path: %s", cli.URL+path)
+	}
 	request, err := cli.buildRequest(http.MethodGet, cli.URL+path, nil)
 	if err != nil {
 		return nil, err
@@ -48,13 +51,13 @@ func (cli Client) Get(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = httpIsValid(response)
+	err = cli.IsValid(response)
 	if err != nil {
 		return nil, err
 	}
 	data, err := ioutil.ReadAll(response.Body)
 	if cli.Debug && err == nil {
-		log.Printf("GET, Path: %s, Data: %s", path, string(data))
+		log.Printf("GET, Data: %s", string(data))
 	}
 	response.Body.Close()
 	return data, err
@@ -62,28 +65,31 @@ func (cli Client) Get(path string) ([]byte, error) {
 
 // Post sends an HTTP POST request
 func (cli Client) Post(path string, jsonBytes []byte) error {
-	response, err := cli.PostRaw(path, jsonBytes)
+	response, err := cli.PostRaw(path, jsonBytes, "application/json")
 	if err != nil {
 		return err
 	}
-	return httpIsValid(response)
+	return cli.IsValid(response)
 }
 
 // PostRaw sends an HTTP POST request, returning the raw response
-func (cli Client) PostRaw(path string, jsonBytes []byte) (*http.Response, error) {
+func (cli Client) PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error) {
 	if cli.Debug {
-		log.Printf("POST, Path: %s, Data: %s", path, string(jsonBytes))
+		log.Printf("POST, Path: %s, Data: %s", cli.URL+path, string(dataBytes))
 	}
-	request, err := cli.buildRequest(http.MethodPost, cli.URL+path, bytes.NewBuffer(jsonBytes))
+	request, err := cli.buildRequest(http.MethodPost, cli.URL+path, bytes.NewBuffer(dataBytes))
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Content-Type", contentType)
 	return cli.getHTTPClient().Do(request)
 }
 
 // Delete sends an HTTP DELETE request
 func (cli Client) Delete(path string) error {
+	if cli.Debug {
+		log.Printf("DELETE, Path: %s", cli.URL+path)
+	}
 	request, err := cli.buildRequest(http.MethodDelete, cli.URL+path, nil)
 	if err != nil {
 		return err
@@ -92,7 +98,7 @@ func (cli Client) Delete(path string) error {
 	if err != nil {
 		return err
 	}
-	return httpIsValid(response)
+	return cli.IsValid(response)
 }
 
 // Put sends an HTTP PUT request
@@ -109,7 +115,22 @@ func (cli Client) Put(path string, dataBytes []byte, contentType string) error {
 	if err != nil {
 		return err
 	}
-	return httpIsValid(response)
+	return cli.IsValid(response)
+}
+
+// IsValid verifies HTTP response, return an error if it is not valid
+func (cli Client) IsValid(response *http.Response) error {
+	if cli.Debug {
+		log.Printf("Got response: %s", response.Status)
+	}
+	code := response.StatusCode
+	if code == http.StatusOK ||
+		code == http.StatusAccepted ||
+		code == http.StatusNoContent ||
+		code == http.StatusCreated {
+		return nil
+	}
+	return fmt.Errorf("Invalid Response: %s", response.Status)
 }
 
 func (cli Client) buildRequest(method, url string, body io.Reader) (*http.Request, error) {
@@ -143,15 +164,4 @@ func (cli Client) buildRequest(method, url string, body io.Reader) (*http.Reques
 		request = request.WithContext(httptrace.WithClientTrace(request.Context(), trace))
 	}
 	return request, nil
-}
-
-func httpIsValid(response *http.Response) error {
-	code := response.StatusCode
-	if code == http.StatusOK ||
-		code == http.StatusAccepted ||
-		code == http.StatusNoContent ||
-		code == http.StatusCreated {
-		return nil
-	}
-	return fmt.Errorf("Invalid Response: %s", response.Status)
 }

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -75,7 +75,7 @@ func (cli Client) Post(path string, jsonBytes []byte) error {
 // PostRaw sends an HTTP POST request, returning the raw response
 func (cli Client) PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error) {
 	if cli.Debug {
-		log.Printf("POST, Path: %s, Data: %s", cli.URL+path, string(dataBytes))
+		log.Printf("POST, Path: %s, Type: %s, Data: %s", cli.URL+path, contentType, string(dataBytes))
 	}
 	request, err := cli.buildRequest(http.MethodPost, cli.URL+path, bytes.NewBuffer(dataBytes))
 	if err != nil {

--- a/services/events_test.go
+++ b/services/events_test.go
@@ -40,7 +40,7 @@ func (api mockEventRest) Post(path string, jsonBytes []byte) error {
 	return nil
 }
 
-func (api mockEventRest) PostRaw(path string, jsonBytes []byte) (*http.Response, error) {
+func (api mockEventRest) PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error) {
 	return nil, fmt.Errorf("should not be called")
 }
 
@@ -48,8 +48,12 @@ func (api mockEventRest) Delete(path string) error {
 	return fmt.Errorf("should not be called")
 }
 
-func (api mockEventRest) Put(path string, jsonBytes []byte, contentType string) error {
+func (api mockEventRest) Put(path string, dataBytes []byte, contentType string) error {
 	return fmt.Errorf("should not be called")
+}
+
+func (api mockEventRest) IsValid(r *http.Response) error {
+	return nil
 }
 
 func TestSendEvent(t *testing.T) {

--- a/services/foreignSources_test.go
+++ b/services/foreignSources_test.go
@@ -62,7 +62,7 @@ func (api mockForeignSourcesRest) Get(path string) ([]byte, error) {
 	return nil, fmt.Errorf("GET: should not be called with path %s", path)
 }
 
-func (api mockForeignSourcesRest) PostRaw(path string, jsonBytes []byte) (*http.Response, error) {
+func (api mockForeignSourcesRest) PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error) {
 	return &http.Response{}, fmt.Errorf("should not be called")
 }
 
@@ -107,13 +107,17 @@ func (api mockForeignSourcesRest) Delete(path string) error {
 	return fmt.Errorf("DELETE: should not be called with %s", path)
 }
 
-func (api mockForeignSourcesRest) Put(path string, jsonBytes []byte, contentType string) error {
+func (api mockForeignSourcesRest) Put(path string, dataBytes []byte, contentType string) error {
 	switch path {
 	case "/rest/foreignSources/Example":
-		assert.Equal(api.t, "scan-interval=3d", string(jsonBytes))
+		assert.Equal(api.t, "scan-interval=3d", string(dataBytes))
 		return nil
 	}
 	return fmt.Errorf("PUT: should not be called with %s", path)
+}
+
+func (api mockForeignSourcesRest) IsValid(r *http.Response) error {
+	return nil
 }
 
 func TestGetForeignSourceDef(t *testing.T) {

--- a/services/monitoringLocations_test.go
+++ b/services/monitoringLocations_test.go
@@ -45,7 +45,7 @@ func (api mockMonitoringLocationRest) Post(path string, jsonBytes []byte) error 
 	return nil
 }
 
-func (api mockMonitoringLocationRest) PostRaw(path string, jsonBytes []byte) (*http.Response, error) {
+func (api mockMonitoringLocationRest) PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error) {
 	return nil, fmt.Errorf("should not be called")
 }
 
@@ -53,8 +53,12 @@ func (api mockMonitoringLocationRest) Delete(path string) error {
 	return fmt.Errorf("should not be called")
 }
 
-func (api mockMonitoringLocationRest) Put(path string, jsonBytes []byte, contentType string) error {
+func (api mockMonitoringLocationRest) Put(path string, dataBytes []byte, contentType string) error {
 	return fmt.Errorf("should not be called")
+}
+
+func (api mockMonitoringLocationRest) IsValid(r *http.Response) error {
+	return nil
 }
 
 func TestLocationExists(t *testing.T) {

--- a/services/nodes.go
+++ b/services/nodes.go
@@ -26,7 +26,7 @@ func GetNodesAPI(rest api.RestAPI) api.NodesAPI {
 }
 
 func (api nodesAPI) GetNodes() (*model.OnmsNodeList, error) {
-	bytes, err := api.rest.Get(fmt.Sprintf("/api/v2/nodes?limit=%d&offset=0", defaultLimit))
+	bytes, err := api.rest.Get(fmt.Sprintf("/api/v2/nodes?limit=%d&offset=0&orderBy=label", defaultLimit))
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (api nodesAPI) GetNodes() (*model.OnmsNodeList, error) {
 			wg.Add(1)
 			go func(page int, wg *sync.WaitGroup) {
 				defer wg.Done()
-				url := fmt.Sprintf("/api/v2/nodes?limit=%d&offset=%d", defaultLimit, defaultLimit*page)
+				url := fmt.Sprintf("/api/v2/nodes?limit=%d&offset=%d&orderBy=label", defaultLimit, defaultLimit*page)
 				if bytes, err = api.rest.Get(url); err != nil {
 					return
 				}
@@ -158,7 +158,7 @@ func (api nodesAPI) DeleteNodeMetadata(nodeCriteria string, context string, key 
 }
 
 func (api nodesAPI) GetIPInterfaces(nodeCriteria string) (*model.OnmsIPInterfaceList, error) {
-	url := fmt.Sprintf("/api/v2/nodes/%s/ipinterfaces?limit=%d&offset=%d", nodeCriteria, defaultLimit, 0)
+	url := fmt.Sprintf("/api/v2/nodes/%s/ipinterfaces?limit=%d&offset=%d&orderBy=ipAddress", nodeCriteria, defaultLimit, 0)
 	bytes, err := api.rest.Get(url)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (api nodesAPI) GetIPInterfaces(nodeCriteria string) (*model.OnmsIPInterface
 			wg.Add(1)
 			go func(page int, wg *sync.WaitGroup) {
 				defer wg.Done()
-				url := fmt.Sprintf("/api/v2/nodes/%s/ipinterfaces?limit=%d&offset=%d", nodeCriteria, defaultLimit, defaultLimit*page)
+				url := fmt.Sprintf("/api/v2/nodes/%s/ipinterfaces?limit=%d&offset=%d&orderBy=ipAddress", nodeCriteria, defaultLimit, defaultLimit*page)
 				if bytes, err = api.rest.Get(url); err != nil {
 					return
 				}
@@ -266,7 +266,7 @@ func (api nodesAPI) DeleteIPInterfaceMetadata(nodeCriteria string, ipAddress str
 }
 
 func (api nodesAPI) GetSnmpInterfaces(nodeCriteria string) (*model.OnmsSnmpInterfaceList, error) {
-	url := fmt.Sprintf("/api/v2/nodes/%s/snmpinterfaces?limit=%d&offset=%d", nodeCriteria, defaultLimit, 0)
+	url := fmt.Sprintf("/api/v2/nodes/%s/snmpinterfaces?limit=%d&offset=%d&orderBy=ifName", nodeCriteria, defaultLimit, 0)
 	bytes, err := api.rest.Get(url)
 	if err != nil {
 		return nil, err
@@ -288,7 +288,7 @@ func (api nodesAPI) GetSnmpInterfaces(nodeCriteria string) (*model.OnmsSnmpInter
 			wg.Add(1)
 			go func(page int, wg *sync.WaitGroup) {
 				defer wg.Done()
-				url := fmt.Sprintf("/api/v2/nodes/%s/snmpinterfaces?limit=%d&offset=%d", nodeCriteria, defaultLimit, defaultLimit*page)
+				url := fmt.Sprintf("/api/v2/nodes/%s/snmpinterfaces?limit=%d&offset=%d&orderBy=ifName", nodeCriteria, defaultLimit, defaultLimit*page)
 				if bytes, err = api.rest.Get(url); err != nil {
 					return
 				}

--- a/services/nodes_test.go
+++ b/services/nodes_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"log"
 	"net/http"
@@ -25,10 +26,19 @@ var mockNode = &model.OnmsNode{
 	SysDescription: "Mock Node",
 	SNMPInterfaces: []model.OnmsSnmpInterface{
 		{
-			IfIndex:       99,
+			IfIndex:       1097,
 			IfName:        "eth0",
 			IfDescr:       "eth0",
 			IfSpeed:       1000000000,
+			IfType:        6,
+			IfOperStatus:  1,
+			IfAdminStatus: 1,
+		},
+		{
+			IfIndex:       1098,
+			IfName:        "eth1",
+			IfDescr:       "eth1",
+			IfSpeed:       100000000,
 			IfType:        6,
 			IfOperStatus:  1,
 			IfAdminStatus: 1,
@@ -39,7 +49,7 @@ var mockNode = &model.OnmsNode{
 			IPAddress:   "10.0.0.1",
 			HostName:    "test01.example.com",
 			SnmpPrimary: "P",
-			IfIndex:     99,
+			IfIndex:     1097,
 			Services: []model.OnmsMonitoredService{
 				{
 					ServiceType: &model.OnmsServiceType{
@@ -62,6 +72,12 @@ var mockNode = &model.OnmsNode{
 				},
 			},
 		},
+		{
+			IPAddress:   "10.0.0.2",
+			HostName:    "10.0.0.2",
+			SnmpPrimary: "N",
+			IfIndex:     1098,
+		},
 	},
 	Meta: []model.MetaData{
 		{
@@ -82,26 +98,42 @@ type mockNodeRest struct {
 }
 
 func (api mockNodeRest) Get(path string) ([]byte, error) {
+	log.Printf("GET PATH: %s", path)
+	if strings.Contains(path, "/api/v2/nodes?limit=0&_s=") {
+		return nil, nil
+	}
 	if strings.Contains(path, "/nodes?limit=10") {
-		offset := 0
-		re := regexp.MustCompile(`offset=(\d+)`)
-		match := re.FindStringSubmatch(path)
-		if match != nil {
-			offset, _ = strconv.Atoi(match[1])
-		}
-		list := createMockNodeList(48, offset)
+		list := createMockNodeList(48, getOffset(path))
 		return json.Marshal(list)
 	}
-	if strings.HasSuffix(path, "/nodes/10/snmpinterfaces/99") {
-		snmp := mockNode.GetSnmpInterface(99).ExtractBasic()
-		snmp.ID = 11 // Fake Primary Key
+	if strings.Contains(path, "/ipinterfaces?limit=10") {
+		list := createMockIPList(48, getOffset(path))
+		return json.Marshal(list)
+	}
+	if strings.Contains(path, "/snmpinterfaces?limit=10") {
+		list := createMockSNMPList(48, getOffset(path))
+		return json.Marshal(list)
+	}
+	if strings.HasSuffix(path, "/nodes/10/snmpinterfaces/1097") {
+		snmp := mockNode.GetSnmpInterface(1097).ExtractBasic()
+		snmp.ID = 101 // Fake Primary Key
 		return json.Marshal(snmp)
+	}
+	if strings.HasSuffix(path, "/nodes/10/snmpinterfaces/1098") {
+		snmp := mockNode.GetSnmpInterface(1098).ExtractBasic()
+		snmp.ID = 102 // Fake Primary Key
+		return json.Marshal(snmp)
+	}
+	if strings.HasSuffix(path, "/nodes/10/ipinterfaces/10.0.0.1") {
+		ip := mockNode.GetIPInterface("10.0.0.1")
+		ip.ID = 11 // Fake Primary Key
+		return json.Marshal(ip)
 	}
 	return nil, fmt.Errorf("GET should not be called for %s", path)
 }
 
 func (api mockNodeRest) Post(path string, jsonBytes []byte) error {
-	log.Printf("PATH: %s, JSON: %s", path, string(jsonBytes))
+	log.Printf("POST PATH: %s, JSON: %s", path, string(jsonBytes))
 	if strings.HasSuffix(path, "/nodes/10/categories") {
 		cat := &model.OnmsCategory{}
 		if err := json.Unmarshal(jsonBytes, cat); err != nil {
@@ -118,20 +150,10 @@ func (api mockNodeRest) Post(path string, jsonBytes []byte) error {
 			return err
 		}
 		if mockNode.GetIPInterface(intf.IPAddress) == nil {
-			return fmt.Errorf("Received invalid IP Interface %s", string(jsonBytes))
+			return fmt.Errorf("Received IP Interface with invalid IP %s", string(jsonBytes))
 		}
-		if intf.IfIndex > 0 && (intf.SNMPInterface == nil || intf.SNMPInterface.ID != 11) {
-			return fmt.Errorf("Received invalid IP Interface %s", string(jsonBytes))
-		}
-		return nil
-	}
-	if strings.HasSuffix(path, "/nodes/10/snmpinterfaces") {
-		intf := &model.OnmsSnmpInterface{}
-		if err := json.Unmarshal(jsonBytes, intf); err != nil {
-			return err
-		}
-		if mockNode.GetSnmpInterface(intf.IfIndex) == nil {
-			return fmt.Errorf("Received invalid SNMP Interface %s", string(jsonBytes))
+		if intf.IfIndex > 0 && (intf.SNMPInterface == nil || intf.SNMPInterface.ID == 0) {
+			return fmt.Errorf("Received IP Interface with invalid ifIndex %s", string(jsonBytes))
 		}
 		return nil
 	}
@@ -158,8 +180,8 @@ func (api mockNodeRest) Post(path string, jsonBytes []byte) error {
 	return fmt.Errorf("POST should not be called for %s", path)
 }
 
-func (api mockNodeRest) PostRaw(path string, jsonBytes []byte) (*http.Response, error) {
-	log.Printf("PATH: %s, JSON: %s", path, string(jsonBytes))
+func (api mockNodeRest) PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error) {
+	log.Printf("POST PATH (raw): %s, JSON: %s", path, string(dataBytes))
 	if strings.HasSuffix(path, "/nodes") {
 		response := &http.Response{
 			Status:     http.StatusText(http.StatusCreated),
@@ -170,6 +192,19 @@ func (api mockNodeRest) PostRaw(path string, jsonBytes []byte) (*http.Response, 
 		}
 		return response, nil
 	}
+	if strings.HasSuffix(path, "/nodes/10/snmpinterfaces") {
+		intf := &model.OnmsSnmpInterface{}
+		if err := xml.Unmarshal(dataBytes, intf); err != nil {
+			return &http.Response{}, err
+		}
+		return &http.Response{
+			Status:     http.StatusText(http.StatusCreated),
+			StatusCode: http.StatusCreated,
+			Header: http.Header{
+				"Location": []string{fmt.Sprintf("/nodes/10/snmpinterfaces/%d", intf.IfIndex)},
+			},
+		}, nil
+	}
 	return nil, fmt.Errorf("POST-Raw should not be called for %s", path)
 }
 
@@ -177,8 +212,22 @@ func (api mockNodeRest) Delete(path string) error {
 	return fmt.Errorf("DELETE should not be called for %s", path)
 }
 
-func (api mockNodeRest) Put(path string, jsonBytes []byte, contentType string) error {
+func (api mockNodeRest) Put(path string, dataBytes []byte, contentType string) error {
 	return fmt.Errorf("should not be called")
+}
+
+func (api mockNodeRest) IsValid(r *http.Response) error {
+	return nil
+}
+
+func getOffset(path string) int {
+	offset := 0
+	re := regexp.MustCompile(`offset=(\d+)`)
+	match := re.FindStringSubmatch(path)
+	if match != nil {
+		offset, _ = strconv.Atoi(match[1])
+	}
+	return offset
 }
 
 func createMockNodeList(total int, offset int) *model.OnmsNodeList {
@@ -192,6 +241,34 @@ func createMockNodeList(total int, offset int) *model.OnmsNodeList {
 		}
 	}
 	list.Count = len(list.Nodes)
+	return list
+}
+
+func createMockIPList(total int, offset int) *model.OnmsIPInterfaceList {
+	list := &model.OnmsIPInterfaceList{
+		TotalCount: total,
+		Offset:     offset,
+	}
+	for i := offset; i < offset+defaultLimit; i++ {
+		if i < total {
+			list.Interfaces = append(list.Interfaces, model.OnmsIPInterface{IPAddress: fmt.Sprintf("10.0.%d.1", i)})
+		}
+	}
+	list.Count = len(list.Interfaces)
+	return list
+}
+
+func createMockSNMPList(total int, offset int) *model.OnmsSnmpInterfaceList {
+	list := &model.OnmsSnmpInterfaceList{
+		TotalCount: total,
+		Offset:     offset,
+	}
+	for i := offset; i < offset+defaultLimit; i++ {
+		if i < total {
+			list.Interfaces = append(list.Interfaces, model.OnmsSnmpInterface{IfIndex: 1000 + i, IfName: fmt.Sprintf("eth%d", i)})
+		}
+	}
+	list.Count = len(list.Interfaces)
 	return list
 }
 
@@ -209,4 +286,24 @@ func TestGetNodes(t *testing.T) {
 		log.Println(n.Label)
 	}
 	assert.Equal(t, 48, len(list.Nodes))
+}
+
+func TestGetIPInterfaces(t *testing.T) {
+	api := GetNodesAPI(&mockNodeRest{t})
+	list, err := api.GetIPInterfaces("1")
+	assert.NilError(t, err)
+	for _, n := range list.Interfaces {
+		log.Println(n.IPAddress)
+	}
+	assert.Equal(t, 48, len(list.Interfaces))
+}
+
+func TestGetSnmpInterfaces(t *testing.T) {
+	api := GetNodesAPI(&mockNodeRest{t})
+	list, err := api.GetSnmpInterfaces("1")
+	assert.NilError(t, err)
+	for _, n := range list.Interfaces {
+		log.Println(n.IfName)
+	}
+	assert.Equal(t, 48, len(list.Interfaces))
 }

--- a/services/nodes_test.go
+++ b/services/nodes_test.go
@@ -126,7 +126,7 @@ func (api mockNodeRest) Get(path string) ([]byte, error) {
 	}
 	if strings.HasSuffix(path, "/nodes/10/ipinterfaces/10.0.0.1") {
 		ip := mockNode.GetIPInterface("10.0.0.1")
-		ip.ID = 11 // Fake Primary Key
+		ip.ID = "11" // Fake Primary Key
 		return json.Marshal(ip)
 	}
 	return nil, fmt.Errorf("GET should not be called for %s", path)

--- a/services/provisioning_test.go
+++ b/services/provisioning_test.go
@@ -31,7 +31,7 @@ func (api mockProvisioningRest) Post(path string, jsonBytes []byte) error {
 	return fmt.Errorf("should not be called")
 }
 
-func (api mockProvisioningRest) PostRaw(path string, jsonBytes []byte) (*http.Response, error) {
+func (api mockProvisioningRest) PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error) {
 	return nil, fmt.Errorf("should not be called")
 }
 
@@ -39,8 +39,12 @@ func (api mockProvisioningRest) Delete(path string) error {
 	return fmt.Errorf("should not be called")
 }
 
-func (api mockProvisioningRest) Put(path string, jsonBytes []byte, contentType string) error {
+func (api mockProvisioningRest) Put(path string, dataBytes []byte, contentType string) error {
 	return fmt.Errorf("should not be called")
+}
+
+func (api mockProvisioningRest) IsValid(r *http.Response) error {
+	return nil
 }
 
 func TestGetRequisitionNames(t *testing.T) {

--- a/services/requisitions_test.go
+++ b/services/requisitions_test.go
@@ -113,8 +113,12 @@ func (api mockRequisitionsRest) Post(path string, jsonBytes []byte) error {
 	return fmt.Errorf("POST: should not be called with %s", path)
 }
 
-func (api mockRequisitionsRest) PostRaw(path string, jsonBytes []byte) (*http.Response, error) {
+func (api mockRequisitionsRest) PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error) {
 	return nil, fmt.Errorf("should not be called")
+}
+
+func (api mockRequisitionsRest) IsValid(r *http.Response) error {
+	return nil
 }
 
 func (api mockRequisitionsRest) Delete(path string) error {
@@ -141,7 +145,7 @@ func (api mockRequisitionsRest) Delete(path string) error {
 	return fmt.Errorf("DELETE: should not be called with %s", path)
 }
 
-func (api mockRequisitionsRest) Put(path string, jsonBytes []byte, contentType string) error {
+func (api mockRequisitionsRest) Put(path string, dataBytes []byte, contentType string) error {
 	switch path {
 	case "/rest/requisitions/Test1/import?rescanExisting=false":
 		return nil

--- a/services/resources_test.go
+++ b/services/resources_test.go
@@ -45,7 +45,7 @@ func (api mockResourceRest) Post(path string, jsonBytes []byte) error {
 	return fmt.Errorf("should not be called")
 }
 
-func (api mockResourceRest) PostRaw(path string, jsonBytes []byte) (*http.Response, error) {
+func (api mockResourceRest) PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error) {
 	return nil, fmt.Errorf("should not be called")
 }
 
@@ -56,8 +56,12 @@ func (api mockResourceRest) Delete(path string) error {
 	return fmt.Errorf("should not be called")
 }
 
-func (api mockResourceRest) Put(path string, jsonBytes []byte, contentType string) error {
+func (api mockResourceRest) Put(path string, dataBytes []byte, contentType string) error {
 	return fmt.Errorf("should not be called")
+}
+
+func (api mockResourceRest) IsValid(r *http.Response) error {
+	return nil
 }
 
 func TestGetResources(t *testing.T) {

--- a/services/snmp_test.go
+++ b/services/snmp_test.go
@@ -35,7 +35,7 @@ func (api mockSnmpInfoRest) Post(path string, jsonBytes []byte) error {
 	return fmt.Errorf("should not be called")
 }
 
-func (api mockSnmpInfoRest) PostRaw(path string, jsonBytes []byte) (*http.Response, error) {
+func (api mockSnmpInfoRest) PostRaw(path string, dataBytes []byte, contentType string) (*http.Response, error) {
 	return nil, fmt.Errorf("should not be called")
 }
 
@@ -43,11 +43,15 @@ func (api mockSnmpInfoRest) Delete(path string) error {
 	return fmt.Errorf("should not be called")
 }
 
-func (api mockSnmpInfoRest) Put(path string, jsonBytes []byte, contentType string) error {
+func (api mockSnmpInfoRest) Put(path string, dataBytes []byte, contentType string) error {
 	assert.Assert(api.test, strings.HasPrefix(path, "/rest/snmpConfig"))
 	snmp := &model.SnmpInfo{}
-	json.Unmarshal(jsonBytes, snmp)
+	json.Unmarshal(dataBytes, snmp)
 	assert.Assert(api.test, cmp.Equal(mockSnmpInfo, snmp))
+	return nil
+}
+
+func (api mockSnmpInfoRest) IsValid(r *http.Response) error {
 	return nil
 }
 


### PR DESCRIPTION
Adding a simple CLI implementation for listing, adding, and deleting nodes.

To add nodes, they must be placed in a YAML file, for example:

```yaml
nodes:

- label: router1.example.com
  foreignSource: Test
  foreignId: router1
  sysObjectId: .1.3.6.1.4.1.8072.3.2.10
  sysName: router1
  sysLocation: Test
  sysDescription: Mock Device
  ipInterfaces:
  - ipAddress: 10.0.0.1
    ifIndex: 1097 # Associate this IP with an SNMP Interface
    snmpPrimary: P
    services:
    - serviceType:
        name: ICMP
    - serviceType:
        name: SNMP
  snmpInterfaces:
  - ifType: 6
    ifIndex: 1097
    ifDescr: eth0
    ifName: eth0
    ifSpeed: 1000000000
    ifAdminStatus: 1
    ifOperStatus: 1
  - ifType: 6
    ifIndex: 1098
    ifDescr: eth1
    ifName: eth1
    ifSpeed: 100000000
    ifAdminStatus: 1
    ifOperStatus: 1

- label: test01.example.com
  foreignSource: Test
  foreignId: test01
  metaData:
  - key: owner
    value: agalue
    context: web
  categories:
  - name: Production
  ipInterfaces:
  - ipAddress: 10.0.0.1
    hostName: test01.example.com
    snmpPrimary: N
    metaData:
    - key: environment
      value: prod
      context: web
    services:
    - serviceType:
        name: HTTP
      metaData:
      - key: port
        value: "8080"
        context: web
  - ipAddress: 10.0.0.2
    hostName: 10.0.0.2
    snmpPrimary: "N"
```

There were errors found in the Node Service Layer that have been fixed in this PR, as well as some enhancements added to the ReST API layer.