### PR TITLE
Clean up sub-command parameters

### DIFF
--- a/cli/nodes/ipinterfaces.go
+++ b/cli/nodes/ipinterfaces.go
@@ -28,8 +28,9 @@ var IPInterfacesCliCommand = cli.Command{
 			Action:    addIPInterface,
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "ipAddr, i",
-					Usage: "IP Address",
+					Name:     "ipAddr, i",
+					Usage:    "IP Address",
+					Required: true,
 				},
 				cli.StringFlag{
 					Name:  "hostname, n",
@@ -72,16 +73,19 @@ var IPInterfacesCliCommand = cli.Command{
 					ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress>",
 					Flags: []cli.Flag{
 						cli.StringFlag{
-							Name:  "context, c",
-							Usage: "Metadata Context",
+							Name:     "context, c",
+							Usage:    "Metadata Context",
+							Required: true,
 						},
 						cli.StringFlag{
-							Name:  "key, k",
-							Usage: "Metadata Key",
+							Name:     "key, k",
+							Usage:    "Metadata Key",
+							Required: true,
 						},
 						cli.StringFlag{
-							Name:  "value, v",
-							Usage: "Metadata Value",
+							Name:     "value, v",
+							Usage:    "Metadata Value",
+							Required: true,
 						},
 					},
 				},
@@ -92,12 +96,14 @@ var IPInterfacesCliCommand = cli.Command{
 					ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress>",
 					Flags: []cli.Flag{
 						cli.StringFlag{
-							Name:  "context, c",
-							Usage: "Metadata Context",
+							Name:     "context, c",
+							Usage:    "Metadata Context",
+							Required: true,
 						},
 						cli.StringFlag{
-							Name:  "key, k",
-							Usage: "Metadata Key",
+							Name:     "key, k",
+							Usage:    "Metadata Key",
+							Required: true,
 						},
 					},
 				},

--- a/cli/nodes/nodes.go
+++ b/cli/nodes/nodes.go
@@ -29,8 +29,9 @@ var CliCommand = cli.Command{
 			Action: addNode,
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "label, l",
-					Usage: "Node Label",
+					Name:     "label, l",
+					Usage:    "Node Label",
+					Required: true,
 				},
 				cli.StringFlag{
 					Name:  "location, L",
@@ -93,16 +94,19 @@ var CliCommand = cli.Command{
 					ArgsUsage: "<nodeId|foreignSource:foreignID>",
 					Flags: []cli.Flag{
 						cli.StringFlag{
-							Name:  "context, c",
-							Usage: "Metadata Context",
+							Name:     "context, c",
+							Usage:    "Metadata Context",
+							Required: true,
 						},
 						cli.StringFlag{
-							Name:  "key, k",
-							Usage: "Metadata Key",
+							Name:     "key, k",
+							Usage:    "Metadata Key",
+							Required: true,
 						},
 						cli.StringFlag{
-							Name:  "value, v",
-							Usage: "Metadata Value",
+							Name:     "value, v",
+							Usage:    "Metadata Value",
+							Required: true,
 						},
 					},
 				},
@@ -113,12 +117,14 @@ var CliCommand = cli.Command{
 					ArgsUsage: "<nodeId|foreignSource:foreignID>",
 					Flags: []cli.Flag{
 						cli.StringFlag{
-							Name:  "context, c",
-							Usage: "Metadata Context",
+							Name:     "context, c",
+							Usage:    "Metadata Context",
+							Required: true,
 						},
 						cli.StringFlag{
-							Name:  "key, k",
-							Usage: "Metadata Key",
+							Name:     "key, k",
+							Usage:    "Metadata Key",
+							Required: true,
 						},
 					},
 				},

--- a/cli/nodes/services.go
+++ b/cli/nodes/services.go
@@ -50,16 +50,19 @@ var ServicesCliCommand = cli.Command{
 					ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress> <serviceName>",
 					Flags: []cli.Flag{
 						cli.StringFlag{
-							Name:  "context, c",
-							Usage: "Metadata Context",
+							Name:     "context, c",
+							Usage:    "Metadata Context",
+							Required: true,
 						},
 						cli.StringFlag{
-							Name:  "key, k",
-							Usage: "Metadata Key",
+							Name:     "key, k",
+							Usage:    "Metadata Key",
+							Required: true,
 						},
 						cli.StringFlag{
-							Name:  "value, v",
-							Usage: "Metadata Value",
+							Name:     "value, v",
+							Usage:    "Metadata Value",
+							Required: true,
 						},
 					},
 				},
@@ -70,12 +73,14 @@ var ServicesCliCommand = cli.Command{
 					ArgsUsage: "<nodeId|foreignSource:foreignID> <ipAddress> <serviceName>",
 					Flags: []cli.Flag{
 						cli.StringFlag{
-							Name:  "context, c",
-							Usage: "Metadata Context",
+							Name:     "context, c",
+							Usage:    "Metadata Context",
+							Required: true,
 						},
 						cli.StringFlag{
-							Name:  "key, k",
-							Usage: "Metadata Key",
+							Name:     "key, k",
+							Usage:    "Metadata Key",
+							Required: true,
 						},
 					},
 				},

--- a/cli/nodes/snmpinterfaces.go
+++ b/cli/nodes/snmpinterfaces.go
@@ -29,16 +29,19 @@ var SnmpInterfacesCliCommand = cli.Command{
 			Action:    addSnmpInterface,
 			Flags: []cli.Flag{
 				cli.IntFlag{
-					Name:  "ifIndex, i",
-					Usage: "The IF-MIB::ifIndex",
+					Name:     "ifIndex, i",
+					Usage:    "The IF-MIB::ifIndex",
+					Required: true,
 				},
 				cli.IntFlag{
 					Name:  "ifOper, o",
 					Usage: "The IF-MIB::ifOperStatus (1:up, 2:down, 3:testing, 4:unknown, 5:dormant, 6:notPresent, 7:lowerLayerDown)",
+					Value: 1,
 				},
 				cli.IntFlag{
 					Name:  "ifAdmin, A",
 					Usage: "The IF-MIB::ifAdminStatus (1:up, 2:down, 3:testing)",
+					Value: 1,
 				},
 				cli.Int64Flag{
 					Name:  "ifSpeed, s",
@@ -49,8 +52,9 @@ var SnmpInterfacesCliCommand = cli.Command{
 					Usage: "The IF-MIB::ifType",
 				},
 				cli.StringFlag{
-					Name:  "ifName, n",
-					Usage: "The IF-MIB::ifName",
+					Name:     "ifName, n",
+					Usage:    "The IF-MIB::ifName",
+					Required: true,
 				},
 				cli.StringFlag{
 					Name:  "ifDescr, d",
@@ -97,9 +101,9 @@ func getSnmpInterfaces(c *cli.Context) error {
 		return nil
 	}
 	writer := common.NewTableWriter()
-	fmt.Fprintln(writer, "ID\tifIndex\tifDescr\tifName\tifAlias\tifType\tifOperStatus\tifAdminStatus")
+	fmt.Fprintln(writer, "ID\tifIndex\tifDescr\tifName\tifAlias\tifType\tifOperStatus\tifAdminStatus\tCollect\tPoll")
 	for _, n := range list.Interfaces {
-		fmt.Fprintf(writer, "%d\t%d\t%s\t%s\t%s\t%d\t%d\t%d\n", n.ID, n.IfIndex, n.IfDescr, n.IfName, n.IfAlias, n.IfType, n.IfOperStatus, n.IfAdminStatus)
+		fmt.Fprintf(writer, "%d\t%d\t%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\n", n.ID, n.IfIndex, n.IfDescr, n.IfName, n.IfAlias, n.IfType, n.IfOperStatus, n.IfAdminStatus, n.CollectFlag, n.PollFlag)
 	}
 	writer.Flush()
 	return nil

--- a/cli/provisioning/interfaces.go
+++ b/cli/provisioning/interfaces.go
@@ -56,8 +56,8 @@ var InterfacesCliCommand = cli.Command{
 					Usage: "Interface Status: 1 for managed, 3 for unmanaged (yes, I know)",
 				},
 				cli.StringSliceFlag{
-					Name:  "metaData, m",
-					Usage: "A meta-data entry (e.x. --metaData 'foo=bar')",
+					Name:  "metadata, m",
+					Usage: "A metadata entry (e.x. --metadata 'foo=bar')",
 				},
 			},
 			Action:       setInterface,
@@ -81,26 +81,26 @@ var InterfacesCliCommand = cli.Command{
 		{
 			Name:      "meta",
 			ShortName: "m",
-			Usage:     "Manage meta-data",
+			Usage:     "Manage metadata",
 			Subcommands: []cli.Command{
 				{
 					Name:         "list",
-					Usage:        "Gets all meta-data for a given IP Interface",
+					Usage:        "Gets all metadata for a given IP Interface",
 					ArgsUsage:    "<foreignSource> <foreignId> <ipAddress>",
 					Action:       intfListMetaData,
 					BashComplete: ipAddressBashComplete,
 				},
 				{
 					Name:         "set",
-					Usage:        "Adds or updates a meta-data entry for a given IP Interface",
-					ArgsUsage:    "<foreignSource> <foreignId> <ipAddress> <metaData-key> <metaData-value>",
+					Usage:        "Adds or updates a metadata entry for a given IP Interface",
+					ArgsUsage:    "<foreignSource> <foreignId> <ipAddress> <metadata-key> <metadata-value>",
 					Action:       intfSetMetaData,
 					BashComplete: ipAddressBashComplete,
 				},
 				{
 					Name:         "delete",
-					Usage:        "Deletes a meta-data entry from a given IP Interface",
-					ArgsUsage:    "<foreignSource> <foreignId> <ipAddress> <metaData-key>",
+					Usage:        "Deletes a metadata entry from a given IP Interface",
+					ArgsUsage:    "<foreignSource> <foreignId> <ipAddress> <metadata-key>",
 					Action:       intfDeleteMetaData,
 					BashComplete: ipAddressBashComplete,
 				},

--- a/cli/provisioning/nodes.go
+++ b/cli/provisioning/nodes.go
@@ -69,8 +69,8 @@ var NodesCliCommand = cli.Command{
 					Usage: "Parent Node Label",
 				},
 				cli.StringSliceFlag{
-					Name:  "metaData, m",
-					Usage: "A meta-data entry (e.x. --metaData 'foo=bar')",
+					Name:  "metadata, m",
+					Usage: "A metadata entry (e.x. --metadata 'foo=bar')",
 				},
 			},
 		},
@@ -98,26 +98,26 @@ var NodesCliCommand = cli.Command{
 		{
 			Name:      "meta",
 			ShortName: "m",
-			Usage:     "Manage meta-data",
+			Usage:     "Manage metadata",
 			Subcommands: []cli.Command{
 				{
 					Name:         "list",
-					Usage:        "Gets all meta-data for a given node",
+					Usage:        "Gets all metadata for a given node",
 					ArgsUsage:    "<foreignSource> <foreignId>",
 					Action:       nodeListMetaData,
 					BashComplete: foreignIDBashComplete,
 				},
 				{
 					Name:         "set",
-					Usage:        "Adds or updates a meta-data entry for a given node",
-					ArgsUsage:    "<foreignSource> <foreignId> <metaData-key> <metaData-value>",
+					Usage:        "Adds or updates a metadata entry for a given node",
+					ArgsUsage:    "<foreignSource> <foreignId> <metadata-key> <metadata-value>",
 					Action:       nodeSetMetaData,
 					BashComplete: foreignIDBashComplete,
 				},
 				{
 					Name:         "delete",
-					Usage:        "Deletes a meta-data entry from a given node",
-					ArgsUsage:    "<foreignSource> <foreignId> <metaData-key>",
+					Usage:        "Deletes a metadata entry from a given node",
+					ArgsUsage:    "<foreignSource> <foreignId> <metadata-key>",
 					Action:       nodeDeleteMetaData,
 					BashComplete: foreignIDBashComplete,
 				},

--- a/cli/provisioning/services.go
+++ b/cli/provisioning/services.go
@@ -32,8 +32,8 @@ var ServicesCliCommand = cli.Command{
 			BashComplete: servicesBashComplete,
 			Flags: []cli.Flag{
 				cli.StringSliceFlag{
-					Name:  "metaData, m",
-					Usage: "A meta-data entry (e.x. --metaData 'foo=bar')",
+					Name:  "metadata, m",
+					Usage: "A metadata entry (e.x. --metadata 'foo=bar')",
 				},
 			},
 		},
@@ -48,26 +48,26 @@ var ServicesCliCommand = cli.Command{
 		{
 			Name:      "meta",
 			ShortName: "m",
-			Usage:     "Manage meta-data",
+			Usage:     "Manage metadata",
 			Subcommands: []cli.Command{
 				{
 					Name:         "list",
-					Usage:        "Gets all meta-data for a given service",
+					Usage:        "Gets all metadata for a given service",
 					ArgsUsage:    "<foreignSource> <foreignId> <ipAddress> <serviceName>",
 					Action:       svcListMetaData,
 					BashComplete: servicesBashComplete,
 				},
 				{
 					Name:         "set",
-					Usage:        "Adds or updates a meta-data entry for a given service",
-					ArgsUsage:    "<foreignSource> <foreignId> <ipAddress> <serviceName> <metaData-key> <metaData-value>",
+					Usage:        "Adds or updates a metadata entry for a given service",
+					ArgsUsage:    "<foreignSource> <foreignId> <ipAddress> <serviceName> <metadata-key> <metadata-value>",
 					Action:       svcSetMetaData,
 					BashComplete: servicesBashComplete,
 				},
 				{
 					Name:         "delete",
-					Usage:        "Deletes a meta-data entry from a given service",
-					ArgsUsage:    "<foreignSource> <foreignId> <ipAddress> <serviceName> <metaData-key>",
+					Usage:        "Deletes a metadata entry from a given service",
+					ArgsUsage:    "<foreignSource> <foreignId> <ipAddress> <serviceName> <metadata-key>",
 					Action:       svcDeleteMetaData,
 					BashComplete: servicesBashComplete,
 				},

--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -21,9 +21,10 @@ var CliCommand = cli.Command{
 	Usage: "Search OpenNMS database",
 	Flags: []cli.Flag{
 		cli.GenericFlag{
-			Name:  "entity, e",
-			Value: Entities,
-			Usage: "The severity of the event: " + Entities.EnumAsString(),
+			Name:     "entity, e",
+			Value:    Entities,
+			Usage:    "The severity of the event: " + Entities.EnumAsString(),
+			Required: true,
 		},
 		cli.StringFlag{
 			Name:  "filter, f",


### PR DESCRIPTION
* Mark required parameters explicitly.
* Use the term "metadata" (one word) when mentioned.
* Show SNMP Interface status flags.
